### PR TITLE
add increment argument to TopK::add

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ use heavykeeper::TopK;
 let mut topk: TopK<Vec<u8>> = TopK::new(10, 1000, 4, 0.9);
 
 // add some items
-topk.add(b"example item".to_vec());
-topk.add(b"another item".to_vec());
+topk.add(b"example item".to_vec(), 5);
+topk.add(b"another item".to_vec(), 1);
 
 // check the counts
 for node in topk.list() {

--- a/benches/topk_add.rs
+++ b/benches/topk_add.rs
@@ -21,7 +21,7 @@ fn benchmark_topk_add(c: &mut Criterion, num_adds: usize) {
     group.bench_function("Add", |b| {
         b.iter(|| {
             for &key in data.iter() {
-                topk.add(black_box(&key));
+                topk.add(black_box(&key), 1);
             }
         });
     });

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,15 +10,9 @@ fn main() {
     let mut topk: TopK<Vec<u8>> = TopK::new(10, 1000, 4, 0.9);
 
     // Add some example items multiple times to show frequency counting
-    for _ in 0..5 {
-        topk.add(&b"frequent item".to_vec());
-    }
-    
-    for _ in 0..3 {
-        topk.add(&b"less frequent item".to_vec());
-    }
-    
-    topk.add(&b"rare item".to_vec());
+    topk.add(&b"frequent item".to_vec(), 5);
+    topk.add(&b"less frequent item".to_vec(), 3);
+    topk.add(&b"rare item".to_vec(), 1);
 
     // Print the items and their counts in order of frequency
     println!("Top items and their frequencies:");

--- a/examples/ip_files.rs
+++ b/examples/ip_files.rs
@@ -82,7 +82,7 @@ fn main() -> io::Result<()> {
     // add all the keys to the topk struct
     let start = Instant::now();
     for key in &keys {
-        topk.add(key);
+        topk.add(key, 1);
     }
     let duration = start.elapsed();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn process_bytes(bytes: &[u8], topk: &mut TopK<Word>, word: &mut Word) {
             }
             
             // Add to TopK
-            topk.add(word);
+            topk.add(word, 1);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/pmcgleenon/heavykeeper-rs/issues/40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The ability to add multiple counts of an item at once has been introduced. When adding items to the frequency tracker, you can now specify how many times each item should be counted in a single call.

- **Documentation**
  - Updated usage examples in the README and example files to demonstrate the new method for adding items with an explicit count.

- **Tests**
  - Test cases have been updated and expanded to cover the new functionality for adding items with a specified count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->