### PR TITLE
Accept borrowed values

### DIFF
--- a/src/hash_composition.rs
+++ b/src/hash_composition.rs
@@ -10,7 +10,7 @@ pub(crate) struct HashComposer {
 impl HashComposer {
     /// Creates a new HashComposer from a value using the provided hasher
     #[inline]
-    pub fn new<T: Hash, S: BuildHasher>(hasher: &S, value: &T) -> Self {
+    pub fn new<T: Hash + ?Sized, S: BuildHasher>(hasher: &S, value: &T) -> Self {
         let h1 = hasher.hash_one(value);
         let h2 = h1.wrapping_shr(32).wrapping_mul(0x51_7c_c1_b7_27_22_0a_95);
 

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
 use ahash::RandomState;
@@ -33,7 +34,11 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len()
     }
 
-    pub(crate) fn get(&self, item: &T) -> Option<u64> {
+    pub(crate) fn get<Q>(&self, item: &Q) -> Option<u64>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
         self.items.get(item).map(|(count, _)| *count)
     }
 


### PR DESCRIPTION
Hi @pmcgleenon ! Thank you for this great library.
While using it, I noticed that it's not possible to call `query` or `add` on `TopK<String>` with `&str`.
This causes not only minor ergonomic issues but also unnecessary allocations due to `&str` -> `String` conversions.

This PR attempts to address that by leveraging Borrow, similar to how std::collections::HashMap handles it.
I'd appreciate your review. Thanks in advance!