### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/pmcgleenon/heavykeeper-rs/security/code-scanning/1](https://github.com/pmcgleenon/heavykeeper-rs/security/code-scanning/1)

Add an explicit `permissions` block to the workflow with the minimum required scope.

Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), since there is currently only one job and all steps are read-only operations. Set:

- `contents: read`

This preserves existing functionality (`actions/checkout` and cargo commands continue to work) while explicitly constraining `GITHUB_TOKEN`.

File to edit:
- `.github/workflows/rust.yml`  
Add the `permissions` block after the `on:` section (or before `jobs:`) so it is clearly workflow-level.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security by restricting automated process permissions to minimum required levels, reducing the attack surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->