### PR TITLE
feat: add CuckooTopK variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,55 @@ for node in topk.list() {
 }
 ```
 
-# Experimental: `BucketedTopK`
+# Variants
 
-Variant that hashes once per insert into a single bucket of `depth` cells with a linear fingerprint scan. Roughly 2× insert throughput vs `TopK` on Zipf and uniform streams. Not the paper's algorithm and its accuracy bounds do not apply. API mirrors `TopK`. Use when insert throughput dominates.
+The crate ships three top-K sketches that share the same public API
+(`new` / `with_seed` / `with_hasher` / `builder` / `add` / `count` /
+`query` / `list` / `merge`):
 
-# Other Implementations
+| Sketch          | Layout                                           | Insert throughput on Zipf(s=1.2), 1M | Recall @ φ=0.0005 |
+| --------------- | ------------------------------------------------ | -----------------------------------: | ----------------: |
+| `TopK`          | `depth` independent rows × `width` buckets        |                       21.0 Melem / s |             0.942 |
+| `BucketedTopK`  | one bucket of `depth` cells per key               |                       29.0 Melem / s |             0.985 |
+| `CuckooTopK`    | per-bucket lobby + `depth` heavy slots, 2-bucket cuckoo |                       29.8 Melem / s |             1.000 |
+
+Numbers are from `cargo bench --bench topk_vs_bucketed` at `K=100,
+width=4096, depth=4, decay=0.9` on `u64` keys. Recall is from
+`tests/accuracy_compare.rs` (paper-style heavy-hitter test, φ = 0.0005,
+1 M Zipf samples).
+
+`TopK` is the canonical implementation from the paper, with its
+accuracy bounds. `BucketedTopK` and `CuckooTopK` are derived variants —
+they don't carry the paper's row-independence accuracy bounds, but the
+empirical accuracy on Zipf streams is competitive and often better.
+
+Pick by workload:
+
+- **`TopK`** — when you want the published algorithm and its bounds.
+- **`BucketedTopK`** — best general-purpose insert throughput; closest to `TopK`'s cost model with a single bucket per key.
+- **`CuckooTopK`** — best accuracy *and* throughput on heavy-hitter-skewed traffic (the elephant-flow use case). Each bucket has a single lobby cell with probabilistic decay plus `depth` non-decaying heavy slots; promoted items live in one of two cuckoo candidate buckets and are re-homed on collision via a kick chain (bound configurable via `CuckooBuilder::max_kicks`, default 8).
+
+All three support seedable construction, custom hashers, and `merge`
+between compatible instances. Errors are returned via
+`BuilderError`/`MergeError` enums; the infallible constructors
+(`new`, `with_seed`, `with_hasher`) trust the caller. Bucket indexing
+uses an AND-mask fast-path when `width` is a power of two; pick
+power-of-two widths in production for the best per-add cost.
+
+# Real-world packet trace
+
+`examples/ip_files.rs` runs all three sketches over a CAIDA-style trace
+(27.5 M packets, 1.03 M distinct 13-byte flow keys = src IP : src port →
+dst IP : dst port + protocol). Same `K=1000, decay=0.95`, equal cell
+budgets across variants:
+
+| Sketch          | Width × depth          | Throughput | hit\_ratio | ARE on reported | ARE on true top-K |
+| --------------- | ---------------------- | ---------: | ---------: | --------------: | ----------------: |
+| `TopK`          | 16384 × 2              | 14.1 Mpps  |     0.9270 |          0.0050 |            0.0745 |
+| `BucketedTopK`  | 8192 × 4               | 18.1 Mpps  |     0.9860 |          0.0035 |            0.0129 |
+| `CuckooTopK`    | 8192 × (1 + 4 heavy)   | 17.0 Mpps  | **0.9990** |      **0.0012** |        **0.0012** |
+
+# Other HeavyKeeper Implementations
 
 | Name                       | Language | Github Repo                                                                  |
 |----------------------------|----------|------------------------------------------------------------------------------|

--- a/benches/topk_add.rs
+++ b/benches/topk_add.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
-use rand::prelude::*;
-use rand::distr::StandardUniform;
 use heavykeeper::TopK;
+use rand::distr::StandardUniform;
+use rand::prelude::*;
+use std::hint::black_box;
 
 fn benchmark_topk_add(c: &mut Criterion, num_adds: usize) {
     let mut rng = rand::rng();
@@ -15,9 +15,9 @@ fn benchmark_topk_add(c: &mut Criterion, num_adds: usize) {
     }
 
     let mut group = c.benchmark_group(format!("TopK_Add_{}", num_adds));
-    group.sample_size(60); 
-    group.warm_up_time(std::time::Duration::from_secs(3)); 
-    group.measurement_time(std::time::Duration::from_secs(10)); 
+    group.sample_size(60);
+    group.warm_up_time(std::time::Duration::from_secs(3));
+    group.measurement_time(std::time::Duration::from_secs(10));
 
     group.bench_function("Add", |b| {
         b.iter(|| {
@@ -29,7 +29,8 @@ fn benchmark_topk_add(c: &mut Criterion, num_adds: usize) {
     group.finish();
 }
 
-criterion_group!(benches,
+criterion_group!(
+    benches,
     benchmark_topk_add_1,
     benchmark_topk_add_10,
     benchmark_topk_add_100,
@@ -67,4 +68,3 @@ fn benchmark_topk_add_100_000(c: &mut Criterion) {
 fn benchmark_topk_add_1_000_000(c: &mut Criterion) {
     benchmark_topk_add(c, 1_000_000);
 }
-

--- a/benches/topk_list.rs
+++ b/benches/topk_list.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
 use heavykeeper::TopK;
 use rand::prelude::*;
+use std::hint::black_box;
 
 // Benchmark TopK::list() to exercise TopKQueue::iter() with large k.
 fn benchmark_topk_list(c: &mut Criterion) {

--- a/benches/topk_vs_bucketed.rs
+++ b/benches/topk_vs_bucketed.rs
@@ -1,12 +1,13 @@
-//! Head-to-head insert: `TopK` vs `BucketedTopK` on identical streams,
-//! same parameters. Workloads: Zipf(s=1.2) and uniform random.
+//! Head-to-head insert benchmark for `TopK`, `BucketedTopK`, and
+//! `CuckooTopK` on identical streams, same parameters.
+//! Workloads: Zipf(s=1.2) and uniform random.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::hint::black_box;
 
-use heavykeeper::{BucketedTopK, TopK};
-use rand::SeedableRng;
+use heavykeeper::{BucketedTopK, CuckooTopK, TopK};
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 use rand_distr::{Distribution, Zipf};
 
 const K: usize = 100;
@@ -45,16 +46,35 @@ fn bench_workload(c: &mut Criterion, group_name: &str, data: &[u64]) {
         );
     });
 
-    group.bench_with_input(BenchmarkId::new("BucketedTopK", data.len()), &data, |b, data| {
-        b.iter_with_setup(
-            || BucketedTopK::<u64>::with_seed(K, WIDTH, DEPTH, DECAY, SEED),
-            |mut topk| {
-                for k in data.iter() {
-                    topk.add(black_box(k), 1);
-                }
-            },
-        );
-    });
+    group.bench_with_input(
+        BenchmarkId::new("BucketedTopK", data.len()),
+        &data,
+        |b, data| {
+            b.iter_with_setup(
+                || BucketedTopK::<u64>::with_seed(K, WIDTH, DEPTH, DECAY, SEED),
+                |mut topk| {
+                    for k in data.iter() {
+                        topk.add(black_box(k), 1);
+                    }
+                },
+            );
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("CuckooTopK", data.len()),
+        &data,
+        |b, data| {
+            b.iter_with_setup(
+                || CuckooTopK::<u64>::with_seed(K, WIDTH, DEPTH, DECAY, SEED),
+                |mut topk| {
+                    for k in data.iter() {
+                        topk.add(black_box(k), 1);
+                    }
+                },
+            );
+        },
+    );
 
     group.finish();
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -20,12 +20,14 @@ fn main() {
         println!("{}: {}", node.item, node.count);
     }
 
-    // Demonstrate the count() method 
+    // Demonstrate the count() method
     let item = "frequent item";
     println!("\nCount for '{}': {}", item, topk.count(item));
 
-    // Demonstrate the query() method 
-    println!("Is '{}' in top-k? {}", 
+    // Demonstrate the query() method
+    println!(
+        "Is '{}' in top-k? {}",
         item,
-        if topk.query(item) { "yes" } else { "no" });
+        if topk.query(item) { "yes" } else { "no" }
+    );
 }

--- a/examples/ip_files.rs
+++ b/examples/ip_files.rs
@@ -1,44 +1,59 @@
-use std::collections::HashMap;
+use heavykeeper::{BucketedTopK, CuckooTopK, TopK};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{self, Read, BufReader};
-use std::time::Instant;
-use heavykeeper::TopK;
+use std::io::{self, BufReader, Read};
+use std::time::{Duration, Instant};
 
 const KEY_SIZE: usize = 13;
+const TOP_K: usize = 1000;
+const DECAY: f64 = 0.95;
 
-fn read_in_trace(trace_prefix: &str, max_item_num: usize) -> io::Result<(Vec<Vec<u8>>, HashMap<Vec<u8>, u32>)> {
+#[allow(dead_code)]
+fn read_in_trace(
+    trace_prefix: &str,
+    max_item_num: usize,
+) -> io::Result<(Vec<Vec<u8>>, HashMap<Vec<u8>, u32>)> {
     let mut count = 0;
     let mut keys = Vec::new();
     let mut actual_flow_sizes = HashMap::new();
 
     let datafile_cnt = 0;
-    //for datafile_cnt in 0..=10 {
-        let trace_file_path = format!("{}{}.dat", trace_prefix, datafile_cnt);
-        println!("Start reading {}", trace_file_path);
+    let trace_file_path = format!("{}{}.dat", trace_prefix, datafile_cnt);
+    println!("Start reading {}", trace_file_path);
 
-        let file = File::open(&trace_file_path)?;
-        let mut reader = BufReader::new(file);
-        let mut temp = vec![0; KEY_SIZE];
+    let file = File::open(&trace_file_path)?;
+    let mut reader = BufReader::new(file);
+    let mut temp = vec![0; KEY_SIZE];
 
-        while reader.read_exact(&mut temp).is_ok() {
-            let key = temp.clone();
-            keys.push(key.clone());
-            let counter = actual_flow_sizes.entry(key).or_insert(0);
-            *counter += 1;
-            count += 1;
+    while reader.read_exact(&mut temp).is_ok() {
+        let key = temp.clone();
+        keys.push(key.clone());
+        let counter = actual_flow_sizes.entry(key).or_insert(0);
+        *counter += 1;
+        count += 1;
 
-            if count >= max_item_num {
-                panic!("The dataset has more than {} items, set a larger value for max_item_num", max_item_num);
-            }
+        if count >= max_item_num {
+            panic!(
+                "The dataset has more than {} items, set a larger value for max_item_num",
+                max_item_num
+            );
         }
+    }
 
-        println!("Finished reading {} ({} items), the dataset now has {} items", trace_file_path, count, keys.len());
-    //}
+    println!(
+        "Finished reading {} ({} items), the dataset now has {} items",
+        trace_file_path,
+        count,
+        keys.len()
+    );
 
     Ok((keys, actual_flow_sizes))
 }
 
-fn read_in_traces(trace_prefix: &str, max_item_num: usize) -> io::Result<(Vec<Vec<u8>>, HashMap<Vec<u8>, u32>)> {
+fn read_in_traces(
+    trace_prefix: &str,
+    max_item_num: usize,
+) -> io::Result<(Vec<Vec<u8>>, HashMap<Vec<u8>, u32>)> {
     let mut count = 0;
     let mut keys = Vec::new();
     let mut actual_flow_sizes = HashMap::new();
@@ -59,14 +74,127 @@ fn read_in_traces(trace_prefix: &str, max_item_num: usize) -> io::Result<(Vec<Ve
             count += 1;
 
             if count >= max_item_num {
-                panic!("The dataset has more than {} items, set a larger value for max_item_num", max_item_num);
+                panic!(
+                    "The dataset has more than {} items, set a larger value for max_item_num",
+                    max_item_num
+                );
             }
         }
 
-        println!("Finished reading {} ({} items), the dataset now has {} items", trace_file_path, count, keys.len());
+        println!(
+            "Finished reading {} ({} items), the dataset now has {} items",
+            trace_file_path,
+            count,
+            keys.len()
+        );
     }
 
     Ok((keys, actual_flow_sizes))
+}
+
+fn format_flow(item: &[u8]) -> String {
+    let src_ip = format!("{}.{}.{}.{}", item[0], item[1], item[2], item[3]);
+    let src_port = u16::from_be_bytes([item[4], item[5]]);
+    let dst_ip = format!("{}.{}.{}.{}", item[6], item[7], item[8], item[9]);
+    let dst_port = u16::from_be_bytes([item[10], item[11]]);
+    let protocol = item[12];
+    format!(
+        "{} {}:{} -> {}:{}",
+        protocol, src_ip, src_port, dst_ip, dst_port
+    )
+}
+
+fn true_top_k(truth: &HashMap<Vec<u8>, u32>, k: usize) -> Vec<(Vec<u8>, u32)> {
+    let mut v: Vec<(Vec<u8>, u32)> = truth.iter().map(|(k, c)| (k.clone(), *c)).collect();
+    // Sort by count descending; ties broken by key bytes for determinism.
+    v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    v.truncate(k);
+    v
+}
+
+struct AccuracyMetrics {
+    /// Fraction of reported items that are in the true top-K.
+    hit_ratio: f64,
+    /// Average relative error of reported items' counts vs. their true counts
+    /// (skips reported items that don't appear in ground truth).
+    are_reported: f64,
+    /// Average relative error over the *true* top-K — uses the sketch's
+    /// own `count(item)` query, so missing items count as zero.
+    are_true_top_k: f64,
+}
+
+fn score_results(
+    results: &[(Vec<u8>, u64)],
+    truth: &HashMap<Vec<u8>, u32>,
+    true_top_set: &HashSet<Vec<u8>>,
+    sketch_count: impl Fn(&[u8]) -> u64,
+) -> AccuracyMetrics {
+    let hits = results
+        .iter()
+        .filter(|(item, _)| true_top_set.contains(item))
+        .count();
+    let hit_ratio = if results.is_empty() {
+        0.0
+    } else {
+        hits as f64 / results.len() as f64
+    };
+
+    let mut sum = 0.0;
+    let mut n = 0usize;
+    for (item, est) in results {
+        if let Some(&true_c) = truth.get(item) {
+            if true_c > 0 {
+                sum += (*est as f64 - true_c as f64).abs() / true_c as f64;
+                n += 1;
+            }
+        }
+    }
+    let are_reported = if n == 0 { 0.0 } else { sum / n as f64 };
+
+    let mut sum_true = 0.0;
+    let true_n = true_top_set.len();
+    for item in true_top_set {
+        let est = sketch_count(item);
+        let true_c = truth[item] as f64;
+        sum_true += (est as f64 - true_c).abs() / true_c;
+    }
+    let are_true_top_k = if true_n == 0 {
+        0.0
+    } else {
+        sum_true / true_n as f64
+    };
+
+    AccuracyMetrics {
+        hit_ratio,
+        are_reported,
+        are_true_top_k,
+    }
+}
+
+fn report(
+    name: &str,
+    num_keys: usize,
+    duration: Duration,
+    results: &[(Vec<u8>, u64)],
+    metrics: &AccuracyMetrics,
+) {
+    let secs = duration.as_secs_f64();
+    let throughput_mpps = (num_keys as f64 / 1_000_000.0) / secs;
+    println!("\n=== {} ===", name);
+    println!("inserts: {} in {:.3}s", num_keys, secs);
+    println!(
+        "throughput: {:.2} Mpps, {:.1} ns/op",
+        throughput_mpps,
+        1_000.0 / throughput_mpps
+    );
+    println!(
+        "accuracy: hit_ratio={:.4}  ARE_reported={:.6}  ARE_true_top_k={:.6}",
+        metrics.hit_ratio, metrics.are_reported, metrics.are_true_top_k
+    );
+    println!("top {} flows:", results.len().min(10));
+    for (item, count) in results.iter().take(10) {
+        println!("  {} count={}", format_flow(item), count);
+    }
 }
 
 fn main() -> io::Result<()> {
@@ -76,41 +204,70 @@ fn main() -> io::Result<()> {
     println!("number of items: {}", keys.len());
     println!("number of flows: {}", actual_flow_sizes.len());
 
-    // create a topk struct
-    let mut topk = TopK::new(1000, 21124, 2, 0.95);
+    let truth_top_k = true_top_k(&actual_flow_sizes, TOP_K);
+    let true_top_set: HashSet<Vec<u8>> = truth_top_k.iter().map(|(k, _)| k.clone()).collect();
+    println!(
+        "ground-truth top-{} threshold count: {} (smallest count in true top-K)",
+        TOP_K,
+        truth_top_k.last().map(|(_, c)| *c).unwrap_or(0)
+    );
 
-    // add all the keys to the topk struct
-    let start = Instant::now();
-    for key in &keys {
-        topk.add(key, 1);
+    // Power-of-two widths so all three variants can use AND-mask bucket
+    // indexing instead of `%`. Roughly comparable cell budgets:
+    //   TopK         : 2 * 16384 = 32768 cells
+    //   BucketedTopK : 8192 * 4  = 32768 cells
+    //   CuckooTopK   : 8192 * 5  = 40960 cells (1 lobby + 4 heavy per bucket)
+
+    {
+        let mut topk = TopK::<Vec<u8>>::new(TOP_K, 16384, 2, DECAY);
+        let start = Instant::now();
+        for key in &keys {
+            topk.add(key.as_slice(), 1);
+        }
+        let duration = start.elapsed();
+        let results: Vec<(Vec<u8>, u64)> =
+            topk.list().into_iter().map(|n| (n.item, n.count)).collect();
+        let metrics = score_results(&results, &actual_flow_sizes, &true_top_set, |item| {
+            topk.count(item)
+        });
+        report(
+            "TopK (HeavyKeeper)",
+            keys.len(),
+            duration,
+            &results,
+            &metrics,
+        );
     }
-    let duration = start.elapsed();
 
-    // calculate throughput
-    let num_of_seconds = duration.as_secs_f64();
-    let throughput = (keys.len() as f64 / 1_000_000.0) / num_of_seconds;
-    println!("use {} seconds", num_of_seconds);
-    println!("throughput: {} Mpps, each insert operation uses {} ns", throughput, 1_000.0 / throughput);
+    {
+        let mut topk = BucketedTopK::<Vec<u8>>::new(TOP_K, 8192, 4, DECAY);
+        let start = Instant::now();
+        for key in &keys {
+            topk.add(key.as_slice(), 1);
+        }
+        let duration = start.elapsed();
+        let results: Vec<(Vec<u8>, u64)> =
+            topk.list().into_iter().map(|n| (n.item, n.count)).collect();
+        let metrics = score_results(&results, &actual_flow_sizes, &true_top_set, |item| {
+            topk.count(item)
+        });
+        report("BucketedTopK", keys.len(), duration, &results, &metrics);
+    }
 
-    for node in topk.list() {
-        // Each 13-byte record has fields in this order:
-        // - Source IP (4 bytes)
-        // - Source Port (2 bytes)
-        // - Destination IP (4 bytes)
-        // - Destination Port (2 bytes)
-        // - Protocol (1 byte)
-
-        let src_ip = format!("{}.{}.{}.{}", 
-            node.item[0], node.item[1], node.item[2], node.item[3]);
-        let src_port = u16::from_be_bytes([node.item[4], node.item[5]]);
-        let dst_ip = format!("{}.{}.{}.{}", 
-            node.item[6], node.item[7], node.item[8], node.item[9]);
-        let dst_port = u16::from_be_bytes([node.item[10], node.item[11]]);
-        let protocol = node.item[12];
-
-        println!("{} {}:{} -> {}:{} {}", protocol, src_ip, src_port, dst_ip, dst_port, node.count);
+    {
+        let mut topk = CuckooTopK::<Vec<u8>>::new(TOP_K, 8192, 4, DECAY);
+        let start = Instant::now();
+        for key in &keys {
+            topk.add(key.as_slice(), 1);
+        }
+        let duration = start.elapsed();
+        let results: Vec<(Vec<u8>, u64)> =
+            topk.list().into_iter().map(|n| (n.item, n.count)).collect();
+        let metrics = score_results(&results, &actual_flow_sizes, &true_top_set, |item| {
+            topk.count(item)
+        });
+        report("CuckooTopK", keys.len(), duration, &results, &metrics);
     }
 
     Ok(())
 }
-

--- a/examples/ip_files.rs
+++ b/examples/ip_files.rs
@@ -73,7 +73,7 @@ fn read_in_traces(
             *counter += 1;
             count += 1;
 
-            if count >= max_item_num {
+            if count > max_item_num {
                 panic!(
                     "The dataset has more than {} items, set a larger value for max_item_num",
                     max_item_num

--- a/examples/word_count.rs
+++ b/examples/word_count.rs
@@ -1,10 +1,10 @@
-use std::io::{self, BufRead};
-use memmap2::Mmap;
-use std::process::exit;
 use clap::Parser;
 use heavykeeper::TopK;
-use std::hash::{Hash, Hasher};
+use memmap2::Mmap;
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::io::{self, BufRead};
+use std::process::exit;
 
 const MAX_WORD_LEN: usize = 64;
 
@@ -104,7 +104,7 @@ fn main() {
         let stdin = io::stdin();
         let mut stdin_lock = stdin.lock();
         let mut buffer = Vec::with_capacity(1024 * 1024);
-        
+
         while stdin_lock.read_until(b'\n', &mut buffer).unwrap() > 0 {
             process_bytes(&buffer, &mut topk, &mut word);
             buffer.clear();
@@ -152,12 +152,12 @@ fn process_bytes(bytes: &[u8], topk: &mut TopK<Word>, word: &mut Word) {
         if word_len > 0 && word_len <= MAX_WORD_LEN {
             // Clear and reuse the word
             word.clear();
-            
+
             // Convert to lowercase while copying
             for &b in &bytes[word_start..pos] {
                 word.push(b.to_ascii_lowercase());
             }
-            
+
             // Add to TopK
             topk.add(word, 1);
         }

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -7,8 +7,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use ahash::RandomState;
-use rand::{RngCore, SeedableRng};
 use rand::rngs::SmallRng;
+use rand::{RngCore, SeedableRng};
 use thiserror::Error;
 
 use crate::priority_queue::TopKQueue;
@@ -19,18 +19,18 @@ const DECAY_LOOKUP_SIZE: usize = 1024;
 const MERGE_HASHER_PROBE: &[u8] = b"heavykeeper-merge-compat-probe";
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Node<T> {
+pub struct BucketedNode<T> {
     pub item: T,
     pub count: u64,
 }
 
-impl<T: Ord> Ord for Node<T> {
+impl<T: Ord> Ord for BucketedNode<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         other.count.cmp(&self.count)
     }
 }
 
-impl<T: Ord> PartialOrd for Node<T> {
+impl<T: Ord> PartialOrd for BucketedNode<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -40,16 +40,25 @@ impl<T: Ord> PartialOrd for Node<T> {
 #[derive(Error, Debug)]
 pub enum BucketedMergeError {
     #[error("Incompatible width: self ({self_width}) != other ({other_width})")]
-    IncompatibleWidth { self_width: usize, other_width: usize },
+    IncompatibleWidth {
+        self_width: usize,
+        other_width: usize,
+    },
 
     #[error("Incompatible depth: self ({self_depth}) != other ({other_depth})")]
-    IncompatibleDepth { self_depth: usize, other_depth: usize },
+    IncompatibleDepth {
+        self_depth: usize,
+        other_depth: usize,
+    },
 
     #[error("Incompatible decay: self ({self_decay}) != other ({other_decay})")]
     IncompatibleDecay { self_decay: f64, other_decay: f64 },
 
     #[error("Incompatible top_items: self ({self_items}) != other ({other_items})")]
-    IncompatibleTopItems { self_items: usize, other_items: usize },
+    IncompatibleTopItems {
+        self_items: usize,
+        other_items: usize,
+    },
 
     #[error("Incompatible hashers: sketches were built with different seeds or hasher state")]
     IncompatibleHasher,
@@ -83,6 +92,9 @@ fn precompute_decay_thresholds(decay: f64, num_entries: usize) -> Box<[u64]> {
 
 pub struct BucketedTopK<T: Ord + Clone + Hash + Debug> {
     width: usize,
+    /// Non-zero when `width` is a power of two and `> 1`; in that case
+    /// bucket indexing uses `hash & width_mask` instead of `% width`.
+    width_mask: usize,
     depth: usize,
     decay: f64,
     cells: Box<[Cell]>,
@@ -105,11 +117,19 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
     }
 
     /// Caller-supplied hasher. Merge compatibility is probe-checked; see `merge`.
-    pub fn with_hasher(k: usize, width: usize, depth: usize, decay: f64, hasher: RandomState) -> Self {
+    pub fn with_hasher(
+        k: usize,
+        width: usize,
+        depth: usize,
+        decay: f64,
+        hasher: RandomState,
+    ) -> Self {
         Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(0))
     }
 
-    pub fn builder() -> BucketedBuilder<T> { BucketedBuilder::new() }
+    pub fn builder() -> BucketedBuilder<T> {
+        BucketedBuilder::new()
+    }
 
     fn with_components(
         k: usize,
@@ -119,15 +139,15 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         hasher: RandomState,
         rng: SmallRng,
     ) -> Self {
-        assert!(width >= 1, "width must be >= 1");
-        assert!(depth >= 1, "depth must be >= 1");
-        assert!(
-            decay.is_finite() && (0.0..=1.0).contains(&decay),
-            "decay must be a finite value in 0.0..=1.0, got {decay}",
-        );
         let priority_queue = TopKQueue::with_capacity_and_hasher(k, hasher.clone());
+        let width_mask = if width > 1 && width.is_power_of_two() {
+            width - 1
+        } else {
+            0
+        };
         Self {
             width,
+            width_mask,
             depth,
             decay,
             cells: vec![Cell::default(); width * depth].into_boxed_slice(),
@@ -137,6 +157,15 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
             rng,
             min_pq_count: 0,
             top_items: k,
+        }
+    }
+
+    #[inline]
+    fn bucket_index(&self, hash: u64) -> usize {
+        if self.width_mask != 0 {
+            (hash as usize) & self.width_mask
+        } else {
+            (hash as usize) % self.width
         }
     }
 
@@ -151,10 +180,12 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
-        if increment == 0 { return; }
+        if increment == 0 {
+            return;
+        }
         let h = self.hasher.hash_one(item);
         let fp = h;
-        let bucket_idx = (h as usize) % self.width;
+        let bucket_idx = self.bucket_index(h);
         let range = self.bucket_range(bucket_idx);
         let bucket_start = range.start;
         let cells = &mut self.cells[range];
@@ -166,7 +197,9 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
 
         for (i, cell) in cells.iter().enumerate() {
             if cell.count == 0 {
-                if first_empty.is_none() { first_empty = Some(i); }
+                if first_empty.is_none() {
+                    first_empty = Some(i);
+                }
                 continue;
             }
             if matched.is_none() && cell.fingerprint == fp {
@@ -217,7 +250,9 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
-        if let Some(c) = self.priority_queue.get(item) { return c; }
+        if let Some(c) = self.priority_queue.get(item) {
+            return c;
+        }
         self.bucket_count(item)
     }
 
@@ -227,10 +262,12 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
         let h = self.hasher.hash_one(item);
-        let bucket_idx = (h as usize) % self.width;
+        let bucket_idx = self.bucket_index(h);
         let cells = &self.cells[self.bucket_range(bucket_idx)];
         for cell in cells {
-            if cell.count > 0 && cell.fingerprint == h { return cell.count; }
+            if cell.count > 0 && cell.fingerprint == h {
+                return cell.count;
+            }
         }
         0
     }
@@ -243,9 +280,14 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         self.count(item) > 0
     }
 
-    pub fn list(&self) -> Vec<Node<T>> {
-        let mut nodes: Vec<Node<T>> = self.priority_queue.iter()
-            .map(|(item, count)| Node { item: item.clone(), count })
+    pub fn list(&self) -> Vec<BucketedNode<T>> {
+        let mut nodes: Vec<BucketedNode<T>> = self
+            .priority_queue
+            .iter()
+            .map(|(item, count)| BucketedNode {
+                item: item.clone(),
+                count,
+            })
             .collect();
         nodes.sort();
         nodes
@@ -257,35 +299,41 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
     pub fn merge(&mut self, other: &Self) -> Result<(), BucketedMergeError> {
         if self.width != other.width {
             return Err(BucketedMergeError::IncompatibleWidth {
-                self_width: self.width, other_width: other.width,
+                self_width: self.width,
+                other_width: other.width,
             });
         }
         if self.depth != other.depth {
             return Err(BucketedMergeError::IncompatibleDepth {
-                self_depth: self.depth, other_depth: other.depth,
+                self_depth: self.depth,
+                other_depth: other.depth,
             });
         }
         if self.decay != other.decay {
             return Err(BucketedMergeError::IncompatibleDecay {
-                self_decay: self.decay, other_decay: other.decay,
+                self_decay: self.decay,
+                other_decay: other.decay,
             });
         }
         if self.top_items != other.top_items {
             return Err(BucketedMergeError::IncompatibleTopItems {
-                self_items: self.top_items, other_items: other.top_items,
+                self_items: self.top_items,
+                other_items: other.top_items,
             });
         }
-        if self.hasher.hash_one(MERGE_HASHER_PROBE)
-            != other.hasher.hash_one(MERGE_HASHER_PROBE)
-        {
+        if self.hasher.hash_one(MERGE_HASHER_PROBE) != other.hasher.hash_one(MERGE_HASHER_PROBE) {
             return Err(BucketedMergeError::IncompatibleHasher);
         }
 
         // PQ merge before cell merge so we read pre-merge bucket counts.
-        let other_pq_pairs: Vec<(T, u64)> = other.priority_queue.iter()
+        let other_pq_pairs: Vec<(T, u64)> = other
+            .priority_queue
+            .iter()
             .map(|(item, count)| (item.clone(), count))
             .collect();
-        let self_only_updates: Vec<(T, u64)> = self.priority_queue.iter()
+        let self_only_updates: Vec<(T, u64)> = self
+            .priority_queue
+            .iter()
             .filter(|(item, _)| other.priority_queue.get(item).is_none())
             .map(|(item, self_pq)| {
                 let other_bucket = other.bucket_count(item);
@@ -310,7 +358,9 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
 
             for o in other_start..other_start + self.depth {
                 let oc = other.cells[o];
-                if oc.count == 0 { continue; }
+                if oc.count == 0 {
+                    continue;
+                }
 
                 let mut matched: Option<usize> = None;
                 let mut first_empty: Option<usize> = None;
@@ -320,7 +370,9 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
                 for i in self_start..self_end {
                     let sc = self.cells[i];
                     if sc.count == 0 {
-                        if first_empty.is_none() { first_empty = Some(i); }
+                        if first_empty.is_none() {
+                            first_empty = Some(i);
+                        }
                         continue;
                     }
                     if sc.fingerprint == oc.fingerprint {
@@ -359,18 +411,7 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         let mut remaining = increment;
         while remaining > 0 {
             let current_count = self.cells[cell_idx].count;
-            let count_idx = current_count as usize;
-            let threshold = if count_idx < self.decay_thresholds.len() {
-                self.decay_thresholds[count_idx]
-            } else {
-                let tbl = &self.decay_thresholds;
-                let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
-                let divisor = tbl.len() - 1;
-                let q = count_idx / divisor;
-                let r = count_idx % divisor;
-                let rem_thr = tbl[r] as f64 / u64::MAX as f64;
-                ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
-            };
+            let threshold = self.decay_threshold(current_count);
             if self.rng.next_u64() < threshold {
                 let cell = &mut self.cells[cell_idx];
                 cell.count = cell.count.saturating_sub(1);
@@ -384,11 +425,30 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         }
         None
     }
+
+    fn decay_threshold(&self, count: u64) -> u64 {
+        if count < self.decay_thresholds.len() as u64 {
+            return self.decay_thresholds[count as usize];
+        }
+        let tbl = &self.decay_thresholds;
+        let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
+        let divisor = (tbl.len() - 1) as u64;
+        let q = count / divisor;
+        let r = (count % divisor) as usize;
+        let rem_thr = tbl[r] as f64 / u64::MAX as f64;
+        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+    }
 }
 
 #[cfg(test)]
 impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
-    pub(crate) fn hasher(&self) -> &RandomState { &self.hasher }
+    pub(crate) fn hasher(&self) -> &RandomState {
+        &self.hasher
+    }
+
+    pub(crate) fn decay_threshold_for_test(&self, count: u64) -> u64 {
+        self.decay_threshold(count)
+    }
 }
 
 pub struct BucketedBuilder<T> {
@@ -402,40 +462,87 @@ pub struct BucketedBuilder<T> {
 }
 
 impl<T: Ord + Clone + Hash + Debug> Default for BucketedBuilder<T> {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T: Ord + Clone + Hash + Debug> BucketedBuilder<T> {
     pub fn new() -> Self {
         Self {
-            k: None, width: None, depth: None, decay: None,
-            seed: None, hasher: None,
+            k: None,
+            width: None,
+            depth: None,
+            decay: None,
+            seed: None,
+            hasher: None,
             _phantom: std::marker::PhantomData,
         }
     }
-    pub fn k(mut self, k: usize) -> Self { self.k = Some(k); self }
-    pub fn width(mut self, w: usize) -> Self { self.width = Some(w); self }
-    pub fn depth(mut self, d: usize) -> Self { self.depth = Some(d); self }
-    pub fn decay(mut self, d: f64) -> Self { self.decay = Some(d); self }
-    pub fn seed(mut self, s: u64) -> Self { self.seed = Some(s); self }
-    pub fn hasher(mut self, h: RandomState) -> Self { self.hasher = Some(h); self }
+    pub fn k(mut self, k: usize) -> Self {
+        self.k = Some(k);
+        self
+    }
+    pub fn width(mut self, w: usize) -> Self {
+        self.width = Some(w);
+        self
+    }
+    pub fn depth(mut self, d: usize) -> Self {
+        self.depth = Some(d);
+        self
+    }
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = Some(d);
+        self
+    }
+    pub fn seed(mut self, s: u64) -> Self {
+        self.seed = Some(s);
+        self
+    }
+    pub fn hasher(mut self, h: RandomState) -> Self {
+        self.hasher = Some(h);
+        self
+    }
 
     pub fn build(self) -> Result<BucketedTopK<T>, BucketedBuilderError> {
-        let k = self.k.ok_or_else(|| BucketedBuilderError::MissingField { field: "k".into() })?;
-        let width = self.width.ok_or_else(|| BucketedBuilderError::MissingField { field: "width".into() })?;
-        let depth = self.depth.ok_or_else(|| BucketedBuilderError::MissingField { field: "depth".into() })?;
-        let decay = self.decay.ok_or_else(|| BucketedBuilderError::MissingField { field: "decay".into() })?;
-        if width < 1 { return Err(BucketedBuilderError::InvalidWidth { width }); }
-        if depth < 1 { return Err(BucketedBuilderError::InvalidDepth { depth }); }
+        let k = self
+            .k
+            .ok_or_else(|| BucketedBuilderError::MissingField { field: "k".into() })?;
+        let width = self
+            .width
+            .ok_or_else(|| BucketedBuilderError::MissingField {
+                field: "width".into(),
+            })?;
+        let depth = self
+            .depth
+            .ok_or_else(|| BucketedBuilderError::MissingField {
+                field: "depth".into(),
+            })?;
+        let decay = self
+            .decay
+            .ok_or_else(|| BucketedBuilderError::MissingField {
+                field: "decay".into(),
+            })?;
+        if width < 1 {
+            return Err(BucketedBuilderError::InvalidWidth { width });
+        }
+        if depth < 1 {
+            return Err(BucketedBuilderError::InvalidDepth { depth });
+        }
         if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
             return Err(BucketedBuilderError::InvalidDecay { decay });
         }
         let hasher = self.hasher.unwrap_or_else(|| {
-            if let Some(s) = self.seed { RandomState::with_seeds(s, s, s, s) }
-            else { RandomState::new() }
+            if let Some(s) = self.seed {
+                RandomState::with_seeds(s, s, s, s)
+            } else {
+                RandomState::new()
+            }
         });
         let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
-        Ok(BucketedTopK::with_components(k, width, depth, decay, hasher, rng))
+        Ok(BucketedTopK::with_components(
+            k, width, depth, decay, hasher, rng,
+        ))
     }
 }
 
@@ -529,7 +636,10 @@ mod tests {
         let mut a: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 64, 4, 0.9);
         let b: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 32, 4, 0.9);
         match a.merge(&b) {
-            Err(BucketedMergeError::IncompatibleWidth { self_width, other_width }) => {
+            Err(BucketedMergeError::IncompatibleWidth {
+                self_width,
+                other_width,
+            }) => {
                 assert_eq!(self_width, 64);
                 assert_eq!(other_width, 32);
             }
@@ -542,7 +652,10 @@ mod tests {
         let mut a: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 64, 4, 0.9);
         let b: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 64, 2, 0.9);
         match a.merge(&b) {
-            Err(BucketedMergeError::IncompatibleDepth { self_depth, other_depth }) => {
+            Err(BucketedMergeError::IncompatibleDepth {
+                self_depth,
+                other_depth,
+            }) => {
                 assert_eq!(self_depth, 4);
                 assert_eq!(other_depth, 2);
             }
@@ -552,29 +665,58 @@ mod tests {
 
     #[test]
     fn test_builder_missing_fields() {
-        let r = BucketedBuilder::<Vec<u8>>::new().width(64).depth(4).decay(0.9).build();
+        let r = BucketedBuilder::<Vec<u8>>::new()
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .build();
         assert!(matches!(r, Err(BucketedBuilderError::MissingField { field }) if field == "k"));
 
-        let r = BucketedBuilder::<Vec<u8>>::new().k(10).depth(4).decay(0.9).build();
+        let r = BucketedBuilder::<Vec<u8>>::new()
+            .k(10)
+            .depth(4)
+            .decay(0.9)
+            .build();
         assert!(matches!(r, Err(BucketedBuilderError::MissingField { field }) if field == "width"));
 
-        let r = BucketedBuilder::<Vec<u8>>::new().k(10).width(64).decay(0.9).build();
+        let r = BucketedBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .decay(0.9)
+            .build();
         assert!(matches!(r, Err(BucketedBuilderError::MissingField { field }) if field == "depth"));
 
-        let r = BucketedBuilder::<Vec<u8>>::new().k(10).width(64).depth(4).build();
+        let r = BucketedBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .depth(4)
+            .build();
         assert!(matches!(r, Err(BucketedBuilderError::MissingField { field }) if field == "decay"));
     }
 
     #[test]
     fn test_builder_invalid_depth_zero() {
-        let r = BucketedBuilder::<Vec<u8>>::new().k(10).width(64).depth(0).decay(0.9).build();
-        assert!(matches!(r, Err(BucketedBuilderError::InvalidDepth { depth: 0 })));
+        let r = BucketedBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .depth(0)
+            .decay(0.9)
+            .build();
+        assert!(matches!(
+            r,
+            Err(BucketedBuilderError::InvalidDepth { depth: 0 })
+        ));
     }
 
     #[test]
     fn test_builder_accepts_depths_other_than_four() {
         for d in [1usize, 2, 3, 5, 8] {
-            let r = BucketedBuilder::<Vec<u8>>::new().k(10).width(64).depth(d).decay(0.9).build();
+            let r = BucketedBuilder::<Vec<u8>>::new()
+                .k(10)
+                .width(64)
+                .depth(d)
+                .decay(0.9)
+                .build();
             assert!(r.is_ok(), "depth={d} should build");
         }
     }
@@ -614,12 +756,20 @@ mod tests {
         let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 2000, 4, 0.98);
         for i in 0..100u32 {
             let k = format!("item{i}").into_bytes();
-            for _ in 0..=(i as u64) { topk.add(&k, 1); }
+            for _ in 0..=(i as u64) {
+                topk.add(&k, 1);
+            }
         }
         assert_eq!(topk.list().len(), 10);
         let expected: Vec<Vec<u8>> = (90..100).map(|i| format!("item{i}").into_bytes()).collect();
-        let found = expected.iter().filter(|e| topk.list().iter().any(|n| &n.item == *e)).count();
-        assert!(found >= 8, "at least 8 of top 10 should be in list (got {found})");
+        let found = expected
+            .iter()
+            .filter(|e| topk.list().iter().any(|n| &n.item == *e))
+            .count();
+        assert!(
+            found >= 8,
+            "at least 8 of top 10 should be in list (got {found})"
+        );
     }
 
     #[test]
@@ -717,10 +867,18 @@ mod tests {
         let mut a: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 64, 4, 0.9);
         let mut b: BucketedTopK<Vec<u8>> = BucketedTopK::new(3, 64, 4, 0.9);
 
-        for _ in 0..100 { a.add(&b"hot".to_vec(), 1); }
-        for _ in 0..50  { a.add(&b"warm".to_vec(), 1); }
-        for _ in 0..200 { b.add(&b"hot".to_vec(), 1); }
-        for _ in 0..30  { b.add(&b"cool".to_vec(), 1); }
+        for _ in 0..100 {
+            a.add(&b"hot".to_vec(), 1);
+        }
+        for _ in 0..50 {
+            a.add(&b"warm".to_vec(), 1);
+        }
+        for _ in 0..200 {
+            b.add(&b"hot".to_vec(), 1);
+        }
+        for _ in 0..30 {
+            b.add(&b"cool".to_vec(), 1);
+        }
 
         a.merge(&b).unwrap();
 
@@ -756,9 +914,19 @@ mod tests {
     #[test]
     fn test_merge_unseeded_builder_hashers_incompatible() {
         let mut a: BucketedTopK<Vec<u8>> = BucketedTopK::builder()
-            .k(10).width(64).depth(4).decay(0.9).build().unwrap();
+            .k(10)
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .build()
+            .unwrap();
         let b: BucketedTopK<Vec<u8>> = BucketedTopK::builder()
-            .k(10).width(64).depth(4).decay(0.9).build().unwrap();
+            .k(10)
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .build()
+            .unwrap();
         match a.merge(&b) {
             Err(BucketedMergeError::IncompatibleHasher) => {}
             other => panic!("expected IncompatibleHasher, got {:?}", other),
@@ -778,33 +946,22 @@ mod tests {
         let cases = [-0.1f64, 1.1, f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
         for d in cases {
             let res: Result<BucketedTopK<Vec<u8>>, _> = BucketedTopK::builder()
-                .k(10).width(64).depth(4).decay(d).build();
+                .k(10)
+                .width(64)
+                .depth(4)
+                .decay(d)
+                .build();
             match res {
                 Ok(_) => panic!("expected InvalidDecay for {d}, got Ok"),
                 Err(BucketedBuilderError::InvalidDecay { decay }) => {
-                    assert!(decay.is_nan() || decay == d, "got back {decay} for input {d}");
+                    assert!(
+                        decay.is_nan() || decay == d,
+                        "got back {decay} for input {d}"
+                    );
                 }
                 Err(other) => panic!("expected InvalidDecay for {d}, got {other:?}"),
             }
         }
-    }
-
-    #[test]
-    #[should_panic(expected = "decay must be")]
-    fn test_new_panics_on_nan_decay() {
-        let _: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 64, 4, f64::NAN);
-    }
-
-    #[test]
-    #[should_panic(expected = "decay must be")]
-    fn test_new_panics_on_decay_above_one() {
-        let _: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 64, 4, 2.0);
-    }
-
-    #[test]
-    #[should_panic(expected = "decay must be")]
-    fn test_with_seed_panics_on_negative_decay() {
-        let _: BucketedTopK<Vec<u8>> = BucketedTopK::with_seed(10, 64, 4, -0.5, 42);
     }
 
     #[test]
@@ -815,6 +972,23 @@ mod tests {
         assert_eq!(topk.count(&b"x".to_vec()), u64::MAX);
         topk.add(&b"x".to_vec(), 1_000_000);
         assert_eq!(topk.count(&b"x".to_vec()), u64::MAX);
+    }
+
+    #[test]
+    fn test_decay_threshold_no_usize_truncation_for_large_count() {
+        // On 32-bit targets, `count as usize` would truncate u64 counts
+        // greater than u32::MAX, returning a large threshold from the
+        // start of the lookup table instead of a tiny one. Verify that
+        // for counts > u32::MAX the returned threshold is effectively zero
+        // (decay^4_billion underflows to ~0).
+        let topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 64, 4, 0.9);
+        let huge: u64 = (u32::MAX as u64) + 5000;
+        let thr = topk.decay_threshold_for_test(huge);
+        // A buggy 32-bit truncation would return ~u64::MAX (a small lookup index).
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
     }
 
     #[test]
@@ -833,7 +1007,8 @@ mod tests {
         );
         let list = topk.list();
         assert!(
-            list.iter().all(|n| n.item != b"new".to_vec() || n.count < 100),
+            list.iter()
+                .all(|n| n.item != b"new".to_vec() || n.count < 100),
             "new must not appear at heavy's count in top-k list"
         );
     }

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -433,10 +433,12 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
         let tbl = &self.decay_thresholds;
         let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
         let divisor = (tbl.len() - 1) as u64;
-        let q = count / divisor;
+        // q is u64 — use powf(q as f64) instead of powi(q as i32) which
+        // would truncate (not saturate) for q > i32::MAX.
+        let q = (count / divisor) as f64;
         let r = (count % divisor) as usize;
         let rem_thr = tbl[r] as f64 / u64::MAX as f64;
-        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+        ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 }
 
@@ -985,6 +987,20 @@ mod tests {
         let huge: u64 = (u32::MAX as u64) + 5000;
         let thr = topk.decay_threshold_for_test(huge);
         // A buggy 32-bit truncation would return ~u64::MAX (a small lookup index).
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
+    }
+
+    #[test]
+    fn test_decay_threshold_no_powi_i32_overflow_for_huge_count() {
+        // `q = count / 1023` past i32::MAX would truncate (not saturate)
+        // to a negative i32; `powi(neg)` of a fractional base diverges
+        // and the threshold saturates to u64::MAX. Use powf instead.
+        let topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 64, 4, 0.9);
+        let huge: u64 = (i32::MAX as u64) * 2048;
+        let thr = topk.decay_threshold_for_test(huge);
         assert!(
             thr < u64::MAX / 2,
             "expected ~0 threshold for huge count, got {thr}"

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -1,0 +1,1193 @@
+//! Cuckoo-hash HeavyKeeper variant.
+//!
+//! Each bucket is split into a probabilistic-decay "lobby" cell plus `depth`
+//! non-decaying "heavy" slots. New items land in the lobby of their primary
+//! bucket and are promoted to a heavy slot once they outweigh the resident
+//! lobby fingerprint. Heavy items live in one of two candidate buckets
+//! (cuckoo-style); on collision the lower-count occupant is evicted and
+//! re-homed in its other candidate bucket via a bounded kick chain.
+
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use ahash::RandomState;
+use rand::rngs::SmallRng;
+use rand::{RngCore, SeedableRng};
+use thiserror::Error;
+
+use crate::priority_queue::TopKQueue;
+
+const DECAY_LOOKUP_SIZE: usize = 1024;
+
+/// Default upper bound on the cuckoo kick chain. Higher values raise the
+/// effective load factor of the heavy slots (fewer silent drops on
+/// collision) at the cost of worst-case work per `add`. Override with
+/// [`CuckooBuilder::max_kicks`].
+pub const DEFAULT_MAX_CUCKOO_KICKS: usize = 8;
+
+/// Probe hashed at merge time to detect mismatched hashers.
+const MERGE_HASHER_PROBE: &[u8] = b"heavykeeper-merge-compat-probe";
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Error, Debug)]
+pub enum CuckooMergeError {
+    #[error("Incompatible width: self ({self_width}) != other ({other_width})")]
+    IncompatibleWidth {
+        self_width: usize,
+        other_width: usize,
+    },
+
+    #[error("Incompatible depth: self ({self_depth}) != other ({other_depth})")]
+    IncompatibleDepth {
+        self_depth: usize,
+        other_depth: usize,
+    },
+
+    #[error("Incompatible decay: self ({self_decay}) != other ({other_decay})")]
+    IncompatibleDecay { self_decay: f64, other_decay: f64 },
+
+    #[error("Incompatible top_items: self ({self_items}) != other ({other_items})")]
+    IncompatibleTopItems {
+        self_items: usize,
+        other_items: usize,
+    },
+
+    #[error("Incompatible hashers: sketches were built with different seeds or hasher state")]
+    IncompatibleHasher,
+}
+
+#[derive(Error, Debug)]
+pub enum CuckooBuilderError {
+    #[error("Missing required field: {field}")]
+    MissingField { field: String },
+    #[error("Invalid depth {depth}: must be >= 1")]
+    InvalidDepth { depth: usize },
+    #[error("Invalid width {width}: must be >= 1")]
+    InvalidWidth { width: usize },
+    #[error("Invalid decay {decay}: must be a finite value in 0.0..=1.0")]
+    InvalidDecay { decay: f64 },
+    #[error("Invalid max_kicks {max_kicks}: must be >= 1")]
+    InvalidMaxKicks { max_kicks: usize },
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct CuckooNode<T> {
+    pub item: T,
+    pub count: u64,
+}
+
+impl<T: Ord> Ord for CuckooNode<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.count.cmp(&self.count)
+    }
+}
+
+impl<T: Ord> PartialOrd for CuckooNode<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default, Debug)]
+struct Cell {
+    fingerprint: u64,
+    count: u64,
+}
+
+fn precompute_decay_thresholds(decay: f64, num_entries: usize) -> Box<[u64]> {
+    (0..num_entries)
+        .map(|count| (decay.powf(count as f64) * u64::MAX as f64) as u64)
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+#[inline]
+fn mix64(mut x: u64) -> u64 {
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xbf58476d1ce4e5b9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94d049bb133111eb);
+    x ^ (x >> 31)
+}
+
+/// HeavyKeeper variant where each bucket has a probabilistic-decay "lobby"
+/// cell plus `depth` non-decaying "heavy" slots. New items land in the lobby
+/// of their primary bucket and are promoted to a heavy slot once they
+/// outweigh the resident lobby fingerprint. Heavy items live in one of two
+/// candidate buckets (cuckoo-style); on collision the lower-count occupant
+/// is evicted and re-homed in its other candidate bucket via a bounded kick
+/// chain.
+pub struct CuckooTopK<T: Ord + Clone + Hash + Debug> {
+    width: usize,
+    width_mask: usize,
+    depth: usize,
+    decay: f64,
+    lobbies: Box<[Cell]>,
+    heavy: Box<[Cell]>,
+    decay_thresholds: Box<[u64]>,
+    priority_queue: TopKQueue<T>,
+    hasher: RandomState,
+    rng: SmallRng,
+    min_pq_count: u64,
+    top_items: usize,
+    max_kicks: usize,
+}
+
+impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
+    /// Build a `CuckooTopK` with a fixed default seed and the default kick
+    /// limit ([`DEFAULT_MAX_CUCKOO_KICKS`]). Parameters are not validated;
+    /// use [`CuckooTopK::builder`] for a fallible, validated construction
+    /// path.
+    pub fn new(k: usize, width: usize, depth: usize, decay: f64) -> Self {
+        Self::with_seed(k, width, depth, decay, 12345)
+    }
+
+    /// Build a `CuckooTopK` with the given seed for both the hasher and
+    /// internal RNG. Two instances built with the same seed are
+    /// `merge`-compatible. Parameters are not validated; use
+    /// [`CuckooTopK::builder`] for a fallible, validated construction path.
+    pub fn with_seed(k: usize, width: usize, depth: usize, decay: f64, seed: u64) -> Self {
+        let hasher = RandomState::with_seeds(seed, seed, seed, seed);
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            SmallRng::seed_from_u64(seed),
+            DEFAULT_MAX_CUCKOO_KICKS,
+        )
+    }
+
+    /// Build a `CuckooTopK` with a caller-supplied hasher. Merge
+    /// compatibility is probe-checked against the partner's hasher; see
+    /// [`CuckooTopK::merge`]. Parameters are not validated; use
+    /// [`CuckooTopK::builder`] for a fallible, validated construction path.
+    pub fn with_hasher(
+        k: usize,
+        width: usize,
+        depth: usize,
+        decay: f64,
+        hasher: RandomState,
+    ) -> Self {
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            SmallRng::seed_from_u64(0),
+            DEFAULT_MAX_CUCKOO_KICKS,
+        )
+    }
+
+    /// Fluent builder; see [`CuckooBuilder`].
+    pub fn builder() -> CuckooBuilder<T> {
+        CuckooBuilder::new()
+    }
+
+    fn with_components(
+        k: usize,
+        width: usize,
+        depth: usize,
+        decay: f64,
+        hasher: RandomState,
+        rng: SmallRng,
+        max_kicks: usize,
+    ) -> Self {
+        let width_mask = if width > 1 && width.is_power_of_two() {
+            width - 1
+        } else {
+            0
+        };
+
+        Self {
+            width,
+            width_mask,
+            depth,
+            decay,
+            lobbies: vec![Cell::default(); width].into_boxed_slice(),
+            heavy: vec![Cell::default(); width * depth].into_boxed_slice(),
+            decay_thresholds: precompute_decay_thresholds(decay, DECAY_LOOKUP_SIZE),
+            priority_queue: TopKQueue::with_capacity_and_hasher(k, hasher.clone()),
+            hasher,
+            rng,
+            min_pq_count: 0,
+            top_items: k,
+            max_kicks,
+        }
+    }
+
+    /// Insert `increment` occurrences of `item`. Items first land in the
+    /// lobby of their primary bucket and only appear in [`list`] after they
+    /// have been promoted into a heavy slot.
+    ///
+    /// [`list`]: CuckooTopK::list
+    pub fn add<Q>(&mut self, item: &Q, increment: u64)
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        if increment == 0 {
+            return;
+        }
+
+        let fp = self.hasher.hash_one(item);
+        let (primary, alternate) = self.bucket_pair(fp);
+
+        if let Some(idx) = self.find_heavy(fp, primary, alternate) {
+            self.heavy[idx].count = self.heavy[idx].count.saturating_add(increment);
+            self.update_priority_queue(item, self.heavy[idx].count);
+            return;
+        }
+
+        let lobby_count = match self.update_lobby(primary, fp, increment) {
+            Some(count) => count,
+            None => return,
+        };
+
+        if self.promote(fp, lobby_count, primary, alternate) {
+            self.clear_lobby(primary, fp);
+            self.update_priority_queue(item, lobby_count);
+        }
+    }
+
+    /// Estimated count for `item`. Consults the priority queue first
+    /// (max-ever-seen, paper Algorithm 1) before falling back to the raw
+    /// sketch reading via [`bucket_count`].
+    ///
+    /// [`bucket_count`]: CuckooTopK::bucket_count
+    pub fn count<Q>(&self, item: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        if let Some(c) = self.priority_queue.get(item) {
+            return c;
+        }
+        self.bucket_count(item)
+    }
+
+    /// Raw current sketch count for `item`: heavy slot if present, else the
+    /// lobby cell at the primary bucket, else 0. Skips the priority queue
+    /// (so this can be lower than [`count`] for an item that has decayed).
+    ///
+    /// [`count`]: CuckooTopK::count
+    pub fn bucket_count<Q>(&self, item: &Q) -> u64
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        let fp = self.hasher.hash_one(item);
+        let (primary, alternate) = self.bucket_pair(fp);
+        if let Some(idx) = self.find_heavy(fp, primary, alternate) {
+            return self.heavy[idx].count;
+        }
+        let lobby = self.lobbies[primary];
+        if lobby.fingerprint == fp {
+            lobby.count
+        } else {
+            0
+        }
+    }
+
+    /// Returns true if `item` has a non-zero estimated count.
+    pub fn query<Q>(&self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        self.count(item) > 0
+    }
+
+    /// Top-k items currently tracked by the priority queue, sorted by
+    /// descending count. Items still in the lobby (not yet promoted to a
+    /// heavy slot) do not appear here.
+    pub fn list(&self) -> Vec<CuckooNode<T>> {
+        let mut nodes: Vec<CuckooNode<T>> = self
+            .priority_queue
+            .iter()
+            .map(|(item, count)| CuckooNode {
+                item: item.clone(),
+                count,
+            })
+            .collect();
+        nodes.sort();
+        nodes
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn depth(&self) -> usize {
+        self.depth
+    }
+
+    pub fn decay(&self) -> f64 {
+        self.decay
+    }
+
+    pub fn top_items(&self) -> usize {
+        self.top_items
+    }
+
+    /// Maximum number of cuckoo kicks attempted when relocating an evicted
+    /// heavy slot. See [`DEFAULT_MAX_CUCKOO_KICKS`] for the default and
+    /// trade-off.
+    pub fn max_kicks(&self) -> usize {
+        self.max_kicks
+    }
+
+    /// Merge `other` into `self`. Both sketches must share width, depth,
+    /// decay, top_items and a compatible hasher (probe-checked at merge
+    /// time). Heavy fingerprints from `other` are re-inserted into the
+    /// pair of candidate buckets they hash to in `self`; lobby
+    /// fingerprints are unioned without probabilistic decay (merges are
+    /// deterministic). The priority queue is rebuilt from snapshots
+    /// captured before mutation so pre-merge bucket counts can be used as
+    /// fallback for the side that does not already track an item.
+    pub fn merge(&mut self, other: &Self) -> Result<(), CuckooMergeError> {
+        if self.width != other.width {
+            return Err(CuckooMergeError::IncompatibleWidth {
+                self_width: self.width,
+                other_width: other.width,
+            });
+        }
+        if self.depth != other.depth {
+            return Err(CuckooMergeError::IncompatibleDepth {
+                self_depth: self.depth,
+                other_depth: other.depth,
+            });
+        }
+        if self.decay != other.decay {
+            return Err(CuckooMergeError::IncompatibleDecay {
+                self_decay: self.decay,
+                other_decay: other.decay,
+            });
+        }
+        if self.top_items != other.top_items {
+            return Err(CuckooMergeError::IncompatibleTopItems {
+                self_items: self.top_items,
+                other_items: other.top_items,
+            });
+        }
+        if self.hasher.hash_one(MERGE_HASHER_PROBE) != other.hasher.hash_one(MERGE_HASHER_PROBE) {
+            return Err(CuckooMergeError::IncompatibleHasher);
+        }
+
+        // PQ merge runs BEFORE heavy/lobby mutation so `self.bucket_count`
+        // reflects pre-merge state when used as a fallback.
+        let other_pq_pairs: Vec<(T, u64)> = other
+            .priority_queue
+            .iter()
+            .map(|(item, count)| (item.clone(), count))
+            .collect();
+        let self_only_updates: Vec<(T, u64)> = self
+            .priority_queue
+            .iter()
+            .filter(|(item, _)| other.priority_queue.get(item).is_none())
+            .map(|(item, self_pq)| {
+                let other_bucket = other.bucket_count(item);
+                (item.clone(), self_pq.saturating_add(other_bucket))
+            })
+            .collect();
+        for (item, other_pq) in other_pq_pairs {
+            let merged = match self.priority_queue.get(&item) {
+                Some(self_pq) => self_pq.saturating_add(other_pq),
+                None => self.bucket_count(&item).saturating_add(other_pq),
+            };
+            self.priority_queue.upsert(item, merged);
+        }
+        for (item, count) in self_only_updates {
+            self.priority_queue.upsert(item, count);
+        }
+
+        // Walk other's heavy cells; re-insert each fingerprint into self's
+        // candidate buckets via cuckoo semantics.
+        for o_idx in 0..other.heavy.len() {
+            let oc = other.heavy[o_idx];
+            if oc.count == 0 {
+                continue;
+            }
+            let fp = oc.fingerprint;
+            let count = oc.count;
+            let (primary, alternate) = self.bucket_pair(fp);
+
+            if let Some(idx) = self.find_heavy(fp, primary, alternate) {
+                self.heavy[idx].count = self.heavy[idx].count.saturating_add(count);
+                continue;
+            }
+
+            if let Some(idx) = self.find_empty_heavy_in_bucket(primary) {
+                self.heavy[idx] = Cell {
+                    fingerprint: fp,
+                    count,
+                };
+                continue;
+            }
+            if alternate != primary {
+                if let Some(idx) = self.find_empty_heavy_in_bucket(alternate) {
+                    self.heavy[idx] = Cell {
+                        fingerprint: fp,
+                        count,
+                    };
+                    continue;
+                }
+            }
+
+            let (victim_idx, victim_count) = self.min_heavy_in_candidates(primary, alternate);
+            if count > victim_count {
+                let victim_bucket = victim_idx / self.depth;
+                let victim = self.heavy[victim_idx];
+                self.heavy[victim_idx] = Cell {
+                    fingerprint: fp,
+                    count,
+                };
+                self.relocate_victim(victim, victim_bucket);
+            }
+            // else: count too low to evict, drop.
+        }
+
+        // Walk other's lobbies; resolve conflicts deterministically.
+        for o_idx in 0..other.lobbies.len() {
+            let oc = other.lobbies[o_idx];
+            if oc.count == 0 {
+                continue;
+            }
+            let fp = oc.fingerprint;
+            let count = oc.count;
+            let primary = self.bucket_index(fp);
+            let lobby = self.lobbies[primary];
+
+            if lobby.count > 0 && lobby.fingerprint == fp {
+                self.lobbies[primary].count = lobby.count.saturating_add(count);
+            } else if lobby.count == 0 || count > lobby.count {
+                self.lobbies[primary] = Cell {
+                    fingerprint: fp,
+                    count,
+                };
+            }
+            // else: keep self's lobby occupant (higher count wins; ties keep
+            // self deterministically).
+        }
+
+        self.min_pq_count = self.priority_queue.min_count();
+        Ok(())
+    }
+
+    #[inline]
+    fn heavy_range(&self, bucket: usize) -> std::ops::Range<usize> {
+        let start = bucket * self.depth;
+        start..start + self.depth
+    }
+
+    #[inline]
+    fn bucket_index(&self, fingerprint: u64) -> usize {
+        if self.width_mask != 0 {
+            fingerprint as usize & self.width_mask
+        } else {
+            (fingerprint as usize) % self.width
+        }
+    }
+
+    #[inline]
+    fn bucket_pair(&self, fingerprint: u64) -> (usize, usize) {
+        let primary = self.bucket_index(fingerprint);
+        if self.width == 1 {
+            return (primary, primary);
+        }
+
+        let mut alternate = self.bucket_index(mix64(fingerprint ^ 0x9e3779b97f4a7c15));
+        if alternate == primary {
+            alternate = (alternate + 1) % self.width;
+        }
+        (primary, alternate)
+    }
+
+    #[inline]
+    fn find_heavy(&self, fingerprint: u64, primary: usize, alternate: usize) -> Option<usize> {
+        if let Some(idx) = self.find_heavy_in_bucket(fingerprint, primary) {
+            return Some(idx);
+        }
+        if alternate != primary {
+            self.find_heavy_in_bucket(fingerprint, alternate)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn find_heavy_in_bucket(&self, fingerprint: u64, bucket: usize) -> Option<usize> {
+        self.heavy_range(bucket)
+            .find(|&idx| self.heavy[idx].count > 0 && self.heavy[idx].fingerprint == fingerprint)
+    }
+
+    #[inline]
+    fn find_empty_heavy_in_bucket(&self, bucket: usize) -> Option<usize> {
+        self.heavy_range(bucket)
+            .find(|&idx| self.heavy[idx].count == 0)
+    }
+
+    #[inline]
+    fn min_heavy_in_bucket(&self, bucket: usize) -> (usize, u64) {
+        let mut min_idx = bucket * self.depth;
+        let mut min_count = u64::MAX;
+        for idx in self.heavy_range(bucket) {
+            let count = self.heavy[idx].count;
+            if count < min_count {
+                min_idx = idx;
+                min_count = count;
+            }
+        }
+        (min_idx, min_count)
+    }
+
+    #[inline]
+    fn min_heavy_in_candidates(&self, primary: usize, alternate: usize) -> (usize, u64) {
+        let (mut min_idx, mut min_count) = self.min_heavy_in_bucket(primary);
+        if alternate != primary {
+            let (alternate_min_idx, alternate_min_count) = self.min_heavy_in_bucket(alternate);
+            if alternate_min_count < min_count {
+                min_idx = alternate_min_idx;
+                min_count = alternate_min_count;
+            }
+        }
+        (min_idx, min_count)
+    }
+
+    fn update_lobby(&mut self, bucket: usize, fingerprint: u64, increment: u64) -> Option<u64> {
+        let lobby = &mut self.lobbies[bucket];
+        if lobby.count == 0 || lobby.fingerprint == fingerprint {
+            lobby.fingerprint = fingerprint;
+            lobby.count = lobby.count.saturating_add(increment);
+            return Some(lobby.count);
+        }
+
+        self.decay_lobby_and_maybe_replace(bucket, fingerprint, increment)
+    }
+
+    fn clear_lobby(&mut self, bucket: usize, fingerprint: u64) {
+        let lobby = &mut self.lobbies[bucket];
+        if lobby.fingerprint == fingerprint {
+            *lobby = Cell::default();
+        }
+    }
+
+    fn promote(&mut self, fingerprint: u64, count: u64, primary: usize, alternate: usize) -> bool {
+        if let Some(idx) = self.find_empty_heavy_in_bucket(primary) {
+            self.heavy[idx] = Cell { fingerprint, count };
+            return true;
+        }
+
+        if alternate != primary {
+            if let Some(idx) = self.find_empty_heavy_in_bucket(alternate) {
+                self.heavy[idx] = Cell { fingerprint, count };
+                return true;
+            }
+        }
+
+        let (victim_idx, victim_count) = self.min_heavy_in_candidates(primary, alternate);
+        if count <= victim_count {
+            return false;
+        }
+
+        let victim_bucket = victim_idx / self.depth;
+        let victim = self.heavy[victim_idx];
+        self.heavy[victim_idx] = Cell { fingerprint, count };
+        self.relocate_victim(victim, victim_bucket);
+        true
+    }
+
+    fn relocate_victim(&mut self, mut victim: Cell, mut from_bucket: usize) {
+        for _ in 0..self.max_kicks {
+            if victim.count == 0 {
+                return;
+            }
+
+            let (primary, alternate) = self.bucket_pair(victim.fingerprint);
+            let target = if from_bucket == primary {
+                alternate
+            } else {
+                primary
+            };
+            if target == from_bucket {
+                return;
+            }
+
+            if let Some(empty_idx) = self.find_empty_heavy_in_bucket(target) {
+                self.heavy[empty_idx] = victim;
+                return;
+            }
+
+            let (target_min_idx, target_min_count) = self.min_heavy_in_bucket(target);
+            if victim.count <= target_min_count {
+                return;
+            }
+
+            std::mem::swap(&mut self.heavy[target_min_idx], &mut victim);
+            from_bucket = target;
+        }
+    }
+
+    fn decay_lobby_and_maybe_replace(
+        &mut self,
+        bucket: usize,
+        fingerprint: u64,
+        increment: u64,
+    ) -> Option<u64> {
+        let mut remaining = increment;
+        while remaining > 0 {
+            let current_count = self.lobbies[bucket].count;
+            let threshold = self.decay_threshold(current_count);
+            if self.rng.next_u64() < threshold {
+                let lobby = &mut self.lobbies[bucket];
+                lobby.count = lobby.count.saturating_sub(1);
+                if lobby.count == 0 {
+                    lobby.fingerprint = fingerprint;
+                    lobby.count = remaining;
+                    return Some(remaining);
+                }
+            }
+            remaining -= 1;
+        }
+        None
+    }
+
+    fn decay_threshold(&self, count: u64) -> u64 {
+        if count < self.decay_thresholds.len() as u64 {
+            return self.decay_thresholds[count as usize];
+        }
+
+        let tbl = &self.decay_thresholds;
+        let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
+        let divisor = (tbl.len() - 1) as u64;
+        let q = count / divisor;
+        let r = (count % divisor) as usize;
+        let rem_thr = tbl[r] as f64 / u64::MAX as f64;
+        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+    }
+
+    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64)
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        if let Some(current) = self.priority_queue.get(item) {
+            if count > current {
+                self.priority_queue.update_if_present(item, count);
+                self.min_pq_count = self.priority_queue.min_count();
+            }
+            return;
+        }
+
+        if self.priority_queue.is_full() && count <= self.min_pq_count {
+            return;
+        }
+
+        self.priority_queue.upsert(item.to_owned(), count);
+        self.min_pq_count = self.priority_queue.min_count();
+    }
+}
+
+pub struct CuckooBuilder<T> {
+    k: Option<usize>,
+    width: Option<usize>,
+    depth: Option<usize>,
+    decay: Option<f64>,
+    seed: Option<u64>,
+    hasher: Option<RandomState>,
+    max_kicks: Option<usize>,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: Ord + Clone + Hash + Debug> Default for CuckooBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Ord + Clone + Hash + Debug> CuckooBuilder<T> {
+    pub fn new() -> Self {
+        Self {
+            k: None,
+            width: None,
+            depth: None,
+            decay: None,
+            seed: None,
+            hasher: None,
+            max_kicks: None,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+    pub fn k(mut self, k: usize) -> Self {
+        self.k = Some(k);
+        self
+    }
+    pub fn width(mut self, w: usize) -> Self {
+        self.width = Some(w);
+        self
+    }
+    pub fn depth(mut self, d: usize) -> Self {
+        self.depth = Some(d);
+        self
+    }
+    pub fn decay(mut self, d: f64) -> Self {
+        self.decay = Some(d);
+        self
+    }
+    pub fn seed(mut self, s: u64) -> Self {
+        self.seed = Some(s);
+        self
+    }
+    pub fn hasher(mut self, h: RandomState) -> Self {
+        self.hasher = Some(h);
+        self
+    }
+    /// Override the cuckoo kick chain limit; see [`DEFAULT_MAX_CUCKOO_KICKS`].
+    /// Must be `>= 1`.
+    pub fn max_kicks(mut self, n: usize) -> Self {
+        self.max_kicks = Some(n);
+        self
+    }
+
+    pub fn build(self) -> Result<CuckooTopK<T>, CuckooBuilderError> {
+        let k = self
+            .k
+            .ok_or_else(|| CuckooBuilderError::MissingField { field: "k".into() })?;
+        let width = self.width.ok_or_else(|| CuckooBuilderError::MissingField {
+            field: "width".into(),
+        })?;
+        let depth = self.depth.ok_or_else(|| CuckooBuilderError::MissingField {
+            field: "depth".into(),
+        })?;
+        let decay = self.decay.ok_or_else(|| CuckooBuilderError::MissingField {
+            field: "decay".into(),
+        })?;
+        if width < 1 {
+            return Err(CuckooBuilderError::InvalidWidth { width });
+        }
+        if depth < 1 {
+            return Err(CuckooBuilderError::InvalidDepth { depth });
+        }
+        if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
+            return Err(CuckooBuilderError::InvalidDecay { decay });
+        }
+        let max_kicks = self.max_kicks.unwrap_or(DEFAULT_MAX_CUCKOO_KICKS);
+        if max_kicks < 1 {
+            return Err(CuckooBuilderError::InvalidMaxKicks { max_kicks });
+        }
+        let hasher = self.hasher.unwrap_or_else(|| {
+            if let Some(s) = self.seed {
+                RandomState::with_seeds(s, s, s, s)
+            } else {
+                RandomState::new()
+            }
+        });
+        let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
+        Ok(CuckooTopK::with_components(
+            k, width, depth, decay, hasher, rng, max_kicks,
+        ))
+    }
+}
+
+#[cfg(test)]
+impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
+    pub(crate) fn decay_threshold_for_test(&self, count: u64) -> u64 {
+        self.decay_threshold(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_default_params() {
+        let topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 3, 0.9);
+        assert_eq!(topk.width, 64);
+        assert_eq!(topk.depth, 3);
+        assert_eq!(topk.decay, 0.9);
+        assert_eq!(topk.top_items, 10);
+        assert_eq!(topk.lobbies.len(), 64);
+        assert_eq!(topk.heavy.len(), 192);
+    }
+
+    #[test]
+    fn test_add_promotes_to_heavy_and_counts() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 32, 2, 0.9);
+        topk.add(b"alpha".as_slice(), 1);
+        topk.add(b"alpha".as_slice(), 4);
+
+        assert_eq!(topk.count(b"alpha".as_slice()), 5);
+        assert!(topk.query(b"alpha".as_slice()));
+        assert_eq!(topk.list()[0].item, b"alpha".to_vec());
+        assert_eq!(topk.list()[0].count, 5);
+    }
+
+    #[test]
+    fn test_two_candidate_buckets_can_hold_primary_collisions() {
+        let mut topk: CuckooTopK<u64> = CuckooTopK::with_seed(8, 8, 1, 0.9, 7);
+
+        let mut keys = Vec::new();
+        for key in 0..10_000u64 {
+            let fp = topk.hasher.hash_one(key);
+            let (primary, alternate) = topk.bucket_pair(fp);
+            if primary == 0 && alternate != 0 {
+                keys.push(key);
+                if keys.len() == 2 {
+                    break;
+                }
+            }
+        }
+        assert_eq!(keys.len(), 2);
+
+        for _ in 0..10 {
+            topk.add(&keys[0], 1);
+            topk.add(&keys[1], 1);
+        }
+
+        assert_eq!(topk.count(&keys[0]), 10);
+        assert_eq!(topk.count(&keys[1]), 10);
+    }
+
+    #[test]
+    fn test_stronger_lobby_candidate_replaces_heavy_victim() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 1, 1, 0.9);
+
+        for _ in 0..10 {
+            topk.add(b"small".as_slice(), 1);
+        }
+        for _ in 0..20 {
+            topk.add(b"large".as_slice(), 1);
+        }
+
+        assert!(topk.count(b"large".as_slice()) > topk.bucket_count(b"small".as_slice()));
+    }
+
+    #[test]
+    fn test_add_increment_zero_is_noop() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(5, 64, 4, 0.9);
+        topk.add(&b"a".to_vec(), 0);
+        assert_eq!(topk.count(&b"a".to_vec()), 0);
+        assert!(topk.list().is_empty());
+    }
+
+    #[test]
+    fn test_add_count_saturates_on_overflow() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 1, 1, 0.9);
+        topk.add(&b"x".to_vec(), u64::MAX);
+        topk.add(&b"x".to_vec(), 1);
+        assert_eq!(topk.count(&b"x".to_vec()), u64::MAX);
+        topk.add(&b"x".to_vec(), 1_000_000);
+        assert_eq!(topk.count(&b"x".to_vec()), u64::MAX);
+    }
+
+    #[test]
+    fn test_add_more_items_than_capacity() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 100, 4, 0.9);
+        for name in [b"a".to_vec(), b"b".to_vec(), b"c".to_vec(), b"d".to_vec()] {
+            topk.add(&name, 1);
+        }
+        assert!(topk.list().len() <= 2);
+    }
+
+    #[test]
+    fn test_non_ascii_and_emoji() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(5, 100, 4, 0.9);
+        let p = "पुष्पं अस्ति।".as_bytes().to_vec();
+        let emoji = "🚀🌟".as_bytes().to_vec();
+        topk.add(&p, 1);
+        topk.add(&emoji, 1);
+        assert!(topk.query(&p));
+        assert!(topk.query(&emoji));
+        assert_eq!(topk.count(&p), 1);
+        assert_eq!(topk.count(&emoji), 1);
+    }
+
+    #[test]
+    fn test_borrow_str_and_slice() {
+        let mut topk: CuckooTopK<String> = CuckooTopK::new(10, 100, 4, 0.9);
+        topk.add("foo", 1);
+        assert!(topk.query("foo"));
+        assert_eq!(topk.count("foo"), 1);
+
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 100, 4, 0.9);
+        let item: &[u8] = b"foo";
+        topk.add(item, 1);
+        assert!(topk.query(item));
+        assert_eq!(topk.count(item), 1);
+    }
+
+    #[test]
+    fn test_seed_determinism() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(5, 64, 4, 0.9, 42);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(5, 64, 4, 0.9, 42);
+        for i in 0..200u32 {
+            let key = format!("k{i}").into_bytes();
+            for _ in 0..(i as u64 % 7 + 1) {
+                a.add(&key, 1);
+                b.add(&key, 1);
+            }
+        }
+        let la = a.list();
+        let lb = b.list();
+        assert_eq!(la.len(), lb.len());
+        for (na, nb) in la.iter().zip(lb.iter()) {
+            assert_eq!(na.item, nb.item);
+            assert_eq!(na.count, nb.count);
+        }
+    }
+
+    #[test]
+    fn test_builder_missing_fields() {
+        let r = CuckooBuilder::<Vec<u8>>::new()
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .build();
+        assert!(matches!(r, Err(CuckooBuilderError::MissingField { field }) if field == "k"));
+
+        let r = CuckooBuilder::<Vec<u8>>::new()
+            .k(10)
+            .depth(4)
+            .decay(0.9)
+            .build();
+        assert!(matches!(r, Err(CuckooBuilderError::MissingField { field }) if field == "width"));
+
+        let r = CuckooBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .decay(0.9)
+            .build();
+        assert!(matches!(r, Err(CuckooBuilderError::MissingField { field }) if field == "depth"));
+
+        let r = CuckooBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .depth(4)
+            .build();
+        assert!(matches!(r, Err(CuckooBuilderError::MissingField { field }) if field == "decay"));
+    }
+
+    #[test]
+    fn test_builder_invalid_depth_zero() {
+        let r = CuckooBuilder::<Vec<u8>>::new()
+            .k(10)
+            .width(64)
+            .depth(0)
+            .decay(0.9)
+            .build();
+        assert!(matches!(
+            r,
+            Err(CuckooBuilderError::InvalidDepth { depth: 0 })
+        ));
+    }
+
+    #[test]
+    fn test_builder_max_kicks_default_and_override() {
+        let default_topk: CuckooTopK<Vec<u8>> = CuckooTopK::builder()
+            .k(10)
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .build()
+            .unwrap();
+        assert_eq!(default_topk.max_kicks(), DEFAULT_MAX_CUCKOO_KICKS);
+
+        let custom: CuckooTopK<Vec<u8>> = CuckooTopK::builder()
+            .k(10)
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .max_kicks(32)
+            .build()
+            .unwrap();
+        assert_eq!(custom.max_kicks(), 32);
+
+        let infallible: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 4, 0.9);
+        assert_eq!(infallible.max_kicks(), DEFAULT_MAX_CUCKOO_KICKS);
+    }
+
+    #[test]
+    fn test_builder_invalid_max_kicks_zero() {
+        let r: Result<CuckooTopK<Vec<u8>>, _> = CuckooTopK::builder()
+            .k(10)
+            .width(64)
+            .depth(4)
+            .decay(0.9)
+            .max_kicks(0)
+            .build();
+        assert!(matches!(
+            r,
+            Err(CuckooBuilderError::InvalidMaxKicks { max_kicks: 0 })
+        ));
+    }
+
+    #[test]
+    fn test_builder_rejects_decay_out_of_range() {
+        let cases = [-0.1f64, 1.1, f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
+        for d in cases {
+            let res: Result<CuckooTopK<Vec<u8>>, _> = CuckooTopK::builder()
+                .k(10)
+                .width(64)
+                .depth(4)
+                .decay(d)
+                .build();
+            match res {
+                Ok(_) => panic!("expected InvalidDecay for {d}, got Ok"),
+                Err(CuckooBuilderError::InvalidDecay { decay }) => {
+                    assert!(
+                        decay.is_nan() || decay == d,
+                        "got back {decay} for input {d}"
+                    );
+                }
+                Err(other) => panic!("expected InvalidDecay for {d}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_merge_basic() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        a.add(&b"x".to_vec(), 5);
+        a.add(&b"y".to_vec(), 3);
+        b.add(&b"x".to_vec(), 4);
+        b.add(&b"z".to_vec(), 6);
+        a.merge(&b).expect("compatible");
+        assert_eq!(a.count(&b"x".to_vec()), 9);
+        assert_eq!(a.count(&b"z".to_vec()), 6);
+    }
+
+    #[test]
+    fn test_merge_incompatible_width() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 32, 4, 0.9);
+        match a.merge(&b) {
+            Err(CuckooMergeError::IncompatibleWidth {
+                self_width,
+                other_width,
+            }) => {
+                assert_eq!(self_width, 64);
+                assert_eq!(other_width, 32);
+            }
+            _ => panic!("expected IncompatibleWidth"),
+        }
+    }
+
+    #[test]
+    fn test_merge_incompatible_depth() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 2, 0.9);
+        match a.merge(&b) {
+            Err(CuckooMergeError::IncompatibleDepth {
+                self_depth,
+                other_depth,
+            }) => {
+                assert_eq!(self_depth, 4);
+                assert_eq!(other_depth, 2);
+            }
+            _ => panic!("expected IncompatibleDepth"),
+        }
+    }
+
+    #[test]
+    fn test_merge_incompatible_decay() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.8);
+        match a.merge(&b) {
+            Err(CuckooMergeError::IncompatibleDecay {
+                self_decay,
+                other_decay,
+            }) => {
+                assert_eq!(self_decay, 0.9);
+                assert_eq!(other_decay, 0.8);
+            }
+            _ => panic!("expected IncompatibleDecay"),
+        }
+    }
+
+    #[test]
+    fn test_merge_incompatible_top_items() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let b: CuckooTopK<Vec<u8>> = CuckooTopK::new(5, 64, 4, 0.9);
+        match a.merge(&b) {
+            Err(CuckooMergeError::IncompatibleTopItems {
+                self_items,
+                other_items,
+            }) => {
+                assert_eq!(self_items, 3);
+                assert_eq!(other_items, 5);
+            }
+            _ => panic!("expected IncompatibleTopItems"),
+        }
+    }
+
+    #[test]
+    fn test_merge_incompatible_hasher_different_seed() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 64, 4, 0.9, 1);
+        let b: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 64, 4, 0.9, 2);
+        match a.merge(&b) {
+            Err(CuckooMergeError::IncompatibleHasher) => {}
+            other => panic!("expected IncompatibleHasher, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_merge_compatible_with_same_explicit_seed() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 64, 4, 0.9, 7);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 64, 4, 0.9, 7);
+        a.add(&b"x".to_vec(), 3);
+        b.add(&b"x".to_vec(), 4);
+        a.merge(&b).expect("same seed should be compatible");
+        assert_eq!(a.count(&b"x".to_vec()), 7);
+    }
+
+    #[test]
+    fn test_merge_priority_queue_reflects_summed_counts() {
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
+
+        for _ in 0..100 {
+            a.add(&b"hot".to_vec(), 1);
+        }
+        for _ in 0..50 {
+            a.add(&b"warm".to_vec(), 1);
+        }
+        for _ in 0..200 {
+            b.add(&b"hot".to_vec(), 1);
+        }
+        for _ in 0..30 {
+            b.add(&b"cool".to_vec(), 1);
+        }
+
+        a.merge(&b).unwrap();
+
+        assert_eq!(a.count(&b"hot".to_vec()), 300);
+        assert_eq!(a.count(&b"warm".to_vec()), 50);
+        assert_eq!(a.count(&b"cool".to_vec()), 30);
+
+        let list = a.list();
+        assert_eq!(list[0].item, b"hot".to_vec());
+        assert_eq!(list[0].count, 300);
+    }
+
+    #[test]
+    fn test_decay_threshold_no_usize_truncation_for_large_count() {
+        // On 32-bit targets, `count as usize` would truncate u64 counts
+        // greater than u32::MAX, returning a large threshold from the
+        // start of the lookup table instead of a tiny one. Verify that
+        // for counts > u32::MAX the returned threshold is effectively zero
+        // (decay^4_billion underflows to ~0).
+        let topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 4, 0.9);
+        let huge: u64 = (u32::MAX as u64) + 5000;
+        let thr = topk.decay_threshold_for_test(huge);
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
+    }
+}

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -406,15 +406,23 @@ impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
         }
 
         // Walk other's heavy cells; re-insert each fingerprint into self's
-        // candidate buckets via cuckoo semantics.
+        // candidate buckets via cuckoo semantics. If the same fingerprint
+        // is currently in self's lobby for that primary bucket, fold its
+        // count in and clear the lobby — an item should live in heavy XOR
+        // lobby, never both.
         for o_idx in 0..other.heavy.len() {
             let oc = other.heavy[o_idx];
             if oc.count == 0 {
                 continue;
             }
             let fp = oc.fingerprint;
-            let count = oc.count;
+            let mut count = oc.count;
             let (primary, alternate) = self.bucket_pair(fp);
+
+            if self.lobbies[primary].count > 0 && self.lobbies[primary].fingerprint == fp {
+                count = count.saturating_add(self.lobbies[primary].count);
+                self.lobbies[primary] = Cell::default();
+            }
 
             if let Some(idx) = self.find_heavy(fp, primary, alternate) {
                 self.heavy[idx].count = self.heavy[idx].count.saturating_add(count);
@@ -451,7 +459,10 @@ impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
             // else: count too low to evict, drop.
         }
 
-        // Walk other's lobbies; resolve conflicts deterministically.
+        // Walk other's lobbies. If the fingerprint is already heavy in
+        // self (via either candidate bucket), fold the lobby count into
+        // the heavy entry. Otherwise resolve lobby-vs-lobby conflicts
+        // deterministically.
         for o_idx in 0..other.lobbies.len() {
             let oc = other.lobbies[o_idx];
             if oc.count == 0 {
@@ -459,9 +470,14 @@ impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
             }
             let fp = oc.fingerprint;
             let count = oc.count;
-            let primary = self.bucket_index(fp);
-            let lobby = self.lobbies[primary];
+            let (primary, alternate) = self.bucket_pair(fp);
 
+            if let Some(idx) = self.find_heavy(fp, primary, alternate) {
+                self.heavy[idx].count = self.heavy[idx].count.saturating_add(count);
+                continue;
+            }
+
+            let lobby = self.lobbies[primary];
             if lobby.count > 0 && lobby.fingerprint == fp {
                 self.lobbies[primary].count = lobby.count.saturating_add(count);
             } else if lobby.count == 0 || count > lobby.count {
@@ -664,10 +680,13 @@ impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
         let tbl = &self.decay_thresholds;
         let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
         let divisor = (tbl.len() - 1) as u64;
-        let q = count / divisor;
+        // q is u64 — use powf(q as f64) instead of powi(q as i32) which
+        // would truncate (not saturate) for q > i32::MAX and produce a
+        // negative exponent, sending threshold to ∞ for very-hot keys.
+        let q = (count / divisor) as f64;
         let r = (count % divisor) as usize;
         let rem_thr = tbl[r] as f64 / u64::MAX as f64;
-        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+        ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 
     fn update_priority_queue<Q>(&mut self, item: &Q, count: u64)
@@ -1147,6 +1166,42 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_folds_other_lobby_into_self_heavy() {
+        // self has x heavy with a high count; other has x in lobby.
+        // The lobby contribution from other must fold into self's heavy
+        // entry — not be written into self.lobbies alongside it (where
+        // bucket_count() would miss it because it short-circuits on
+        // heavy hits).
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 1, 1, 0.9, 1);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 1, 1, 0.9, 1);
+
+        a.add(&b"x".to_vec(), 1000);
+        b.add(&b"y".to_vec(), 200); // fills b's heavy slot
+        b.add(&b"x".to_vec(), 5); // forced into b's lobby
+
+        a.merge(&b).expect("compatible");
+
+        assert_eq!(a.bucket_count(&b"x".to_vec()), 1005);
+    }
+
+    #[test]
+    fn test_merge_folds_self_lobby_into_incoming_heavy() {
+        // self has x in lobby; other has x heavy. Heavy walk must fold
+        // self's lobby contribution into the incoming count and clear
+        // the lobby so x lives in heavy XOR lobby, never both.
+        let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 1, 1, 0.9, 1);
+        let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::with_seed(10, 1, 1, 0.9, 1);
+
+        a.add(&b"y".to_vec(), 200); // fills a's heavy slot
+        a.add(&b"x".to_vec(), 5); // forced into a's lobby
+        b.add(&b"x".to_vec(), 1000);
+
+        a.merge(&b).expect("compatible");
+
+        assert_eq!(a.bucket_count(&b"x".to_vec()), 1005);
+    }
+
+    #[test]
     fn test_merge_priority_queue_reflects_summed_counts() {
         let mut a: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
         let mut b: CuckooTopK<Vec<u8>> = CuckooTopK::new(3, 64, 4, 0.9);
@@ -1184,6 +1239,23 @@ mod tests {
         // (decay^4_billion underflows to ~0).
         let topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 4, 0.9);
         let huge: u64 = (u32::MAX as u64) + 5000;
+        let thr = topk.decay_threshold_for_test(huge);
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
+    }
+
+    #[test]
+    fn test_decay_threshold_no_powi_i32_overflow_for_huge_count() {
+        // `q = count / 1023` once exceeded i32::MAX, casting to i32
+        // truncated (not saturated) and produced a negative exponent —
+        // `powi(neg_huge)` of a fractional base diverges to ∞ and the
+        // threshold saturated to u64::MAX (always decay) instead of 0
+        // (never decay). Ensure huge counts still produce a tiny threshold.
+        let topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 4, 0.9);
+        // q = huge / 1023 well past i32::MAX (~2.15e9).
+        let huge: u64 = (i32::MAX as u64) * 2048;
         let thr = topk.decay_threshold_for_test(huge);
         assert!(
             thr < u64::MAX / 2,

--- a/src/hash_composition.rs
+++ b/src/hash_composition.rs
@@ -27,12 +27,19 @@ impl HashComposer {
         self.fingerprint
     }
 
-    /// Composes the next hash and returns bucket index
+    /// Composes the next hash and returns the bucket index. When
+    /// `width_mask != 0` the caller has guaranteed `width` is a power of
+    /// two and `width_mask == width - 1`; the AND-shortcut is used in
+    /// that case. Otherwise we fall back to `% width`.
     #[inline]
-    pub fn next_bucket(&mut self, width: u64, depth: usize) -> usize {
+    pub fn next_bucket(&mut self, width: u64, width_mask: usize, depth: usize) -> usize {
         if depth > 0 {
             self.h1 = self.h1.wrapping_add(self.h2).rotate_left(5);
         }
-        (self.h1 % width) as usize
+        if width_mask != 0 {
+            (self.h1 as usize) & width_mask
+        } else {
+            (self.h1 % width) as usize
+        }
     }
-} 
+}

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -1,13 +1,13 @@
+use crate::hash_composition::HashComposer;
+use crate::priority_queue::TopKQueue;
 use ahash::RandomState;
+use rand::rngs::SmallRng;
+use rand::{RngCore, SeedableRng};
 use std::borrow::Borrow;
 use std::clone::Clone;
 use std::fmt::Debug;
 use std::hash::Hash;
-use rand::{SeedableRng, RngCore};
-use rand::rngs::SmallRng;
 use thiserror::Error;
-use crate::priority_queue::TopKQueue;
-use crate::hash_composition::HashComposer;
 
 const DECAY_LOOKUP_SIZE: usize = 1024;
 
@@ -18,18 +18,18 @@ struct Bucket {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Node<T> {
+pub struct TopKNode<T> {
     pub item: T,
     pub count: u64,
 }
 
-impl<T: Ord> Ord for Node<T> {
+impl<T: Ord> Ord for TopKNode<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         other.count.cmp(&self.count) // Reverse ordering for min-heap
     }
 }
 
-impl<T: Ord> PartialOrd for Node<T> {
+impl<T: Ord> PartialOrd for TopKNode<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -43,19 +43,16 @@ pub enum HeavyKeeperError {
         self_width: usize,
         other_width: usize,
     },
-    
+
     #[error("Incompatible depth: self ({self_depth}) != other ({other_depth})")]
     IncompatibleDepth {
         self_depth: usize,
         other_depth: usize,
     },
-    
+
     #[error("Incompatible decay: self ({self_decay}) != other ({other_decay})")]
-    IncompatibleDecay {
-        self_decay: f64,
-        other_decay: f64,
-    },
-    
+    IncompatibleDecay { self_decay: f64, other_decay: f64 },
+
     #[error("Incompatible top_items: self ({self_items}) != other ({other_items})")]
     IncompatibleTopItems {
         self_items: usize,
@@ -72,6 +69,9 @@ pub enum BuilderError {
 pub struct TopK<T: Ord + Clone + Hash + Debug> {
     top_items: usize,
     width: usize,
+    /// Non-zero when `width` is a power of two and `> 1`; the bucket
+    /// index uses `hash & width_mask` instead of `% width`.
+    width_mask: usize,
     depth: usize,
     decay: f64,
     decay_thresholds: Vec<u64>,
@@ -120,20 +120,53 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         Self::with_hasher(k, width, depth, decay, hasher)
     }
 
-    pub fn with_hasher(k: usize, width: usize, depth: usize, decay: f64, hasher: RandomState) -> Self {
-        Self::with_components(k, width, depth, decay, hasher, Box::new(SmallRng::seed_from_u64(0)))
+    pub fn with_hasher(
+        k: usize,
+        width: usize,
+        depth: usize,
+        decay: f64,
+        hasher: RandomState,
+    ) -> Self {
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            Box::new(SmallRng::seed_from_u64(0)),
+        )
     }
 
-    fn with_components(k: usize, width: usize, depth: usize, decay: f64, hasher: RandomState, rng: Box<dyn RngCore + Send + Sync>) -> Self {
+    fn with_components(
+        k: usize,
+        width: usize,
+        depth: usize,
+        decay: f64,
+        hasher: RandomState,
+        rng: Box<dyn RngCore + Send + Sync>,
+    ) -> Self {
         // Pre-allocate with capacity to avoid resizing
         let mut buckets = Vec::with_capacity(depth);
         for _ in 0..depth {
-            buckets.push(vec![Bucket { fingerprint: 0, count: 0 }; width]);
+            buckets.push(vec![
+                Bucket {
+                    fingerprint: 0,
+                    count: 0
+                };
+                width
+            ]);
         }
+
+        let width_mask = if width > 1 && width.is_power_of_two() {
+            width - 1
+        } else {
+            0
+        };
 
         Self {
             top_items: k,
             width,
+            width_mask,
             depth,
             decay,
             decay_thresholds: precompute_decay_thresholds(decay, DECAY_LOOKUP_SIZE),
@@ -157,7 +190,7 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         let mut min_count = u64::MAX;
 
         for i in 0..self.depth {
-            let bucket_idx = composer.next_bucket(self.width as u64, i);
+            let bucket_idx = composer.next_bucket(self.width as u64, self.width_mask, i);
             let bucket = &self.buckets[i][bucket_idx];
 
             if bucket.fingerprint == composer.fingerprint() {
@@ -181,7 +214,7 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         let mut min_count = u64::MAX;
 
         for i in 0..self.depth {
-            let bucket_idx = composer.next_bucket(self.width as u64, i);
+            let bucket_idx = composer.next_bucket(self.width as u64, self.width_mask, i);
             let bucket = &self.buckets[i][bucket_idx];
 
             if bucket.fingerprint == composer.fingerprint() {
@@ -206,7 +239,7 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         let mut min_count = u64::MAX;
 
         for i in 0..self.depth {
-            let bucket_idx = composer.next_bucket(self.width as u64, i);
+            let bucket_idx = composer.next_bucket(self.width as u64, self.width_mask, i);
             let bucket = &self.buckets[i][bucket_idx];
 
             if bucket.fingerprint == composer.fingerprint() {
@@ -226,40 +259,35 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
+        if increment == 0 {
+            return;
+        }
         let mut composer = HashComposer::new(&self.hasher, item);
         let mut max_count: u64 = 0;
 
         for i in 0..self.depth {
-            let bucket_idx = composer.next_bucket(self.width as u64, i);
-            let bucket = &mut self.buckets[i][bucket_idx];
+            let bucket_idx = composer.next_bucket(self.width as u64, self.width_mask, i);
 
-            let matches = bucket.fingerprint == composer.fingerprint();
-            let empty = bucket.count == 0u64;
-            
+            let (matches, empty) = {
+                let bucket = &self.buckets[i][bucket_idx];
+                (
+                    bucket.fingerprint == composer.fingerprint(),
+                    bucket.count == 0u64,
+                )
+            };
+
             if matches || empty {
+                let bucket = &mut self.buckets[i][bucket_idx];
                 bucket.fingerprint = composer.fingerprint();
                 bucket.count += increment;
                 max_count = std::cmp::max(max_count, bucket.count);
             } else {
                 let mut remaining_incr = increment;
                 while remaining_incr > 0 {
-                    let count_idx = bucket.count as usize;
-                    let decay_threshold = if count_idx < self.decay_thresholds.len() {
-                        self.decay_thresholds[count_idx]
-                    } else {
-
-                        let lookup_size = self.decay_thresholds.len();
-                        // Keep extrapolation normalized to the same [0,1] scale as precomputed thresholds.
-                        let base_threshold = self.decay_thresholds[lookup_size - 1] as f64 / u64::MAX as f64;
-                        let divisor = lookup_size - 1;
-                        let quotient = count_idx / divisor;
-                        let remainder = count_idx % divisor;
-                        let remainder_threshold = self.decay_thresholds[remainder] as f64 / u64::MAX as f64;
-                        let decay = base_threshold.powi(quotient as i32) * remainder_threshold;
-                        // Re-scale back into u64 range consistent with precomputed thresholds.
-                        (decay * u64::MAX as f64) as u64
-                    };
+                    let current_count = self.buckets[i][bucket_idx].count;
+                    let decay_threshold = self.decay_threshold(current_count);
                     let rand = self.random.next_u64();
+                    let bucket = &mut self.buckets[i][bucket_idx];
                     if rand < decay_threshold {
                         bucket.count = bucket.count.saturating_sub(1);
 
@@ -276,23 +304,45 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
             }
         }
 
-        // First check if queue is full - this is a cheap O(1) operation
-        if self.priority_queue.is_full() {
-            // Only check min_count if queue is full
-            if max_count < self.priority_queue.min_count() {
-                return;
+        // Paper Algorithm 1: heap value is max(maxv, existing_heap_value).
+        // Item already in PQ → only raise; sketch readings must not drag PQ down.
+        if let Some(current) = self.priority_queue.get(item) {
+            if max_count > current {
+                self.priority_queue.update_if_present(item, max_count);
             }
+            return;
+        }
+
+        if self.priority_queue.is_full() && max_count <= self.priority_queue.min_count() {
+            return;
         }
 
         // Clone the item here since we need to store it in the priority queue
         self.priority_queue.upsert(item.to_owned(), max_count);
     }
 
-    pub fn list(&self) -> Vec<Node<T>> {
-        let mut nodes = self.priority_queue.iter().map(|(item, count)| Node {
-            item: item.clone(),
-            count,
-        }).collect::<Vec<_>>();
+    fn decay_threshold(&self, count: u64) -> u64 {
+        if count < self.decay_thresholds.len() as u64 {
+            return self.decay_thresholds[count as usize];
+        }
+        let tbl = &self.decay_thresholds;
+        let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
+        let divisor = (tbl.len() - 1) as u64;
+        let q = count / divisor;
+        let r = (count % divisor) as usize;
+        let rem_thr = tbl[r] as f64 / u64::MAX as f64;
+        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+    }
+
+    pub fn list(&self) -> Vec<TopKNode<T>> {
+        let mut nodes = self
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: item.clone(),
+                count,
+            })
+            .collect::<Vec<_>>();
         nodes.sort();
         nodes
     }
@@ -318,10 +368,14 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
             println!("Bucket at row {}, column {}: {:?}", i, j, bucket);
         }
         println!("priority_queue: ");
-        let mut nodes = self.priority_queue.iter().map(|(item, count)| Node {
-            item: item.clone(),
-            count,
-        }).collect::<Vec<_>>();
+        let mut nodes = self
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: item.clone(),
+                count,
+            })
+            .collect::<Vec<_>>();
 
         nodes.sort();
         for node in nodes {
@@ -338,14 +392,14 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
                 other_width: other.width,
             });
         }
-        
+
         if self.depth != other.depth {
             return Err(HeavyKeeperError::IncompatibleDepth {
                 self_depth: self.depth,
                 other_depth: other.depth,
             });
         }
-        
+
         if self.decay != other.decay {
             return Err(HeavyKeeperError::IncompatibleDecay {
                 self_decay: self.decay,
@@ -381,6 +435,13 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+impl<T: Ord + Clone + Hash + Debug> TopK<T> {
+    pub(crate) fn decay_threshold_for_test(&self, count: u64) -> u64 {
+        self.decay_threshold(count)
     }
 }
 
@@ -440,10 +501,18 @@ impl<T: Ord + Clone + Hash + Debug> Builder<T> {
     }
 
     pub fn build(self) -> Result<TopK<T>, BuilderError> {
-        let k = self.k.ok_or_else(|| BuilderError::MissingField { field: "k".to_string() })?;
-        let width = self.width.ok_or_else(|| BuilderError::MissingField { field: "width".to_string() })?;
-        let depth = self.depth.ok_or_else(|| BuilderError::MissingField { field: "depth".to_string() })?;
-        let decay = self.decay.ok_or_else(|| BuilderError::MissingField { field: "decay".to_string() })?;
+        let k = self.k.ok_or_else(|| BuilderError::MissingField {
+            field: "k".to_string(),
+        })?;
+        let width = self.width.ok_or_else(|| BuilderError::MissingField {
+            field: "width".to_string(),
+        })?;
+        let depth = self.depth.ok_or_else(|| BuilderError::MissingField {
+            field: "depth".to_string(),
+        })?;
+        let decay = self.decay.ok_or_else(|| BuilderError::MissingField {
+            field: "decay".to_string(),
+        })?;
 
         let hasher = self.hasher.unwrap_or_else(|| {
             if let Some(seed) = self.seed {
@@ -479,11 +548,11 @@ mod tests {
         fn next_u32(&mut self) -> u32 {
             RngCoreTrait::next_u64(self) as u32
         }
-        
+
         fn next_u64(&mut self) -> u64 {
             RngCoreTrait::next_u64(self)
         }
-        
+
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             for chunk in dest.chunks_mut(8) {
                 let value = RngCoreTrait::next_u64(self);
@@ -541,21 +610,33 @@ mod tests {
 
         // Add first item multiple times
         topk.add(&item1, 8);
-        assert_eq!(topk.count(&item1), 8, "Count should match number of additions");
+        assert_eq!(
+            topk.count(&item1),
+            8,
+            "Count should match number of additions"
+        );
 
         // Verify count for non-existent item
-        assert_eq!(topk.count(&item3), 0, "Non-existent item should have count 0");
+        assert_eq!(
+            topk.count(&item3),
+            0,
+            "Non-existent item should have count 0"
+        );
 
         // Add second item many times
         topk.add(&item2, 1337);
-        assert_eq!(topk.count(&item2), 1337, "Count should match number of additions");
+        assert_eq!(
+            topk.count(&item2),
+            1337,
+            "Count should match number of additions"
+        );
     }
 
     /// Tests support for non-ASCII characters and emoji
     #[test]
     fn test_non_ascii_and_emoji() {
         let mut topk: TopK<Vec<u8>> = TopK::new(5, 100, 4, 0.9);
-        
+
         // Test with Hindi text
         let p = "पुष्पं अस्ति।".as_bytes().to_vec();
         // Test with emoji
@@ -657,10 +738,14 @@ mod tests {
 
         assert_eq!(topk.priority_queue.len(), k, "Should have exactly k items");
 
-        let nodes = topk.priority_queue.iter().map(|(item, count)| Node {
-            item: item.clone(),
-            count,
-        }).collect::<Vec<_>>();
+        let nodes = topk
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: item.clone(),
+                count,
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(nodes.len(), 2, "Should have exactly two items");
         assert_eq!(nodes[0].count, 7, "First item should have count 7");
@@ -744,7 +829,7 @@ mod tests {
     fn test_add_varied_input() {
         let k = 10; // Track top-10 items
         let width = 2000; // Increased width
-        let depth = 20;   // Increased depth
+        let depth = 20; // Increased depth
         let decay = 0.98; // Higher decay for more stability
 
         let mut topk: TopK<Vec<u8>> = TopK::new(k, width, depth, decay);
@@ -773,23 +858,35 @@ mod tests {
         );
 
         // Print actual top-k for debugging
-        let top_items = topk.priority_queue.iter().map(|(item, count)| Node {
-            item: std::str::from_utf8(item).unwrap().to_string().into_bytes(),
-            count,
-        }).collect::<Vec<_>>();
+        let top_items = topk
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: std::str::from_utf8(item).unwrap().to_string().into_bytes(),
+                count,
+            })
+            .collect::<Vec<_>>();
 
-        let expected_top_items = (90..100).map(|i| format!("item{}", i).into_bytes()).collect::<Vec<_>>();
+        let expected_top_items = (90..100)
+            .map(|i| format!("item{}", i).into_bytes())
+            .collect::<Vec<_>>();
 
         let mut found = 0;
         for expected_item in expected_top_items.iter() {
             if top_items.iter().any(|node| &node.item == expected_item) {
                 found += 1;
             } else {
-                println!("Warning: Expected item {} not in top-k", std::str::from_utf8(expected_item).unwrap());
+                println!(
+                    "Warning: Expected item {} not in top-k",
+                    std::str::from_utf8(expected_item).unwrap()
+                );
             }
         }
         // Allow at most 2 misses due to sketch randomness
-        assert!(found >= 8, "At least 8 of the top 10 items should be in top-k");
+        assert!(
+            found >= 8,
+            "At least 8 of the top 10 items should be in top-k"
+        );
     }
 
     /// Tests behavior with a large number of duplicates
@@ -808,7 +905,11 @@ mod tests {
         // Add the same item many times
         topk.add(&item, num_additions);
 
-        assert_eq!(topk.count(&item), num_additions, "Count should match number of additions");
+        assert_eq!(
+            topk.count(&item),
+            num_additions,
+            "Count should match number of additions"
+        );
     }
 
     /// Tests behavior with multiple distinct items
@@ -900,8 +1001,7 @@ mod tests {
         // Verify all items have the same frequency
         for node in topk.list() {
             assert_eq!(
-                node.count,
-                frequency,
+                node.count, frequency,
                 "All items should have the same frequency"
             );
         }
@@ -921,7 +1021,7 @@ mod tests {
         for i in 0..3 {
             let item = format!("item{}", i);
             let item_bytes = item.as_bytes().to_vec();
-            topk.add(&item_bytes, i+1);
+            topk.add(&item_bytes, i + 1);
         }
 
         // Verify priority queue size
@@ -932,12 +1032,18 @@ mod tests {
         );
 
         // Verify top-k items
-        let top_items = topk.priority_queue.iter().map(|(item, count)| Node {
-            item: std::str::from_utf8(item).unwrap().to_string().into_bytes(),
-            count,
-        }).collect::<Vec<_>>();
+        let top_items = topk
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: std::str::from_utf8(item).unwrap().to_string().into_bytes(),
+                count,
+            })
+            .collect::<Vec<_>>();
 
-        let expected_top_items = (1..3).map(|i| format!("item{}", i).into_bytes()).collect::<Vec<_>>();
+        let expected_top_items = (1..3)
+            .map(|i| format!("item{}", i).into_bytes())
+            .collect::<Vec<_>>();
 
         for expected_item in expected_top_items.iter() {
             assert!(
@@ -984,11 +1090,7 @@ mod tests {
         let mut hk1 = TopK::with_seed(3, 100, 5, 0.9, seed);
         let mut hk2 = TopK::with_seed(3, 100, 5, 0.9, seed);
 
-        let items = [
-            b"item1".to_vec(),
-            b"item2".to_vec(),
-            b"item3".to_vec(),
-        ];
+        let items = [b"item1".to_vec(), b"item2".to_vec(), b"item3".to_vec()];
 
         // Add items to first instance
         hk1.add(&items[0], 5);
@@ -1000,7 +1102,11 @@ mod tests {
 
         // Merge and verify counts
         hk1.merge(&hk2).unwrap();
-        assert_eq!(hk1.count(&items[0]), 9, "Count should be sum of both instances");
+        assert_eq!(
+            hk1.count(&items[0]),
+            9,
+            "Count should be sum of both instances"
+        );
         assert_eq!(hk1.count(&items[1]), 3, "Count should be preserved");
         assert_eq!(hk1.count(&items[2]), 6, "Count should be preserved");
     }
@@ -1012,7 +1118,10 @@ mod tests {
         let hk2 = TopK::with_seed(3, 50, 5, 0.9, 12345);
 
         match hk1.merge(&hk2) {
-            Err(HeavyKeeperError::IncompatibleWidth { self_width, other_width }) => {
+            Err(HeavyKeeperError::IncompatibleWidth {
+                self_width,
+                other_width,
+            }) => {
                 assert_eq!(self_width, 100, "Self width should be 100");
                 assert_eq!(other_width, 50, "Other width should be 50");
             }
@@ -1027,7 +1136,10 @@ mod tests {
         let hk2 = TopK::with_seed(3, 100, 4, 0.9, 12345);
 
         match hk1.merge(&hk2) {
-            Err(HeavyKeeperError::IncompatibleDepth { self_depth, other_depth }) => {
+            Err(HeavyKeeperError::IncompatibleDepth {
+                self_depth,
+                other_depth,
+            }) => {
                 assert_eq!(self_depth, 5, "Self depth should be 5");
                 assert_eq!(other_depth, 4, "Other depth should be 4");
             }
@@ -1042,11 +1154,7 @@ mod tests {
         let mut hk1 = TopK::with_seed(3, 100, 5, 0.9, seed);
         let mut hk2 = TopK::with_seed(3, 100, 5, 0.9, seed);
 
-        let items = [
-            b"common".to_vec(),
-            b"unique1".to_vec(),
-            b"unique2".to_vec(),
-        ];
+        let items = [b"common".to_vec(), b"unique1".to_vec(), b"unique2".to_vec()];
 
         // Add overlapping items
         hk1.add(&items[0], 5);
@@ -1057,18 +1165,31 @@ mod tests {
 
         // Merge and verify counts
         hk1.merge(&hk2).unwrap();
-        assert_eq!(hk1.count(&items[0]), 10, "Common item count should be doubled");
-        assert_eq!(hk1.count(&items[1]), 1, "Unique item count should be preserved");
-        assert_eq!(hk1.count(&items[2]), 1, "Unique item count should be preserved");
+        assert_eq!(
+            hk1.count(&items[0]),
+            10,
+            "Common item count should be doubled"
+        );
+        assert_eq!(
+            hk1.count(&items[1]),
+            1,
+            "Unique item count should be preserved"
+        );
+        assert_eq!(
+            hk1.count(&items[2]),
+            1,
+            "Unique item count should be preserved"
+        );
     }
 
     #[test]
     fn test_decay_logic_with_mock_rng() {
         let mut mock_rng = MockRngCoreTrait::new();
-        mock_rng.expect_next_u64()
+        mock_rng
+            .expect_next_u64()
             .times(1..) // Allow multiple calls
             .return_const(0u64);
-        
+
         let topk = TopK::<Vec<u8>>::builder()
             .k(1)
             .width(1)
@@ -1077,24 +1198,24 @@ mod tests {
             .rng(mock_rng)
             .build()
             .unwrap();
-        
+
         let item1 = b"item1".to_vec();
         let item2 = b"item2".to_vec(); // Different item to trigger decay
-        
+
         // Add item1 with a very large count (beyond lookup table)
         let large_count = 9999u64;
         let mut topk = topk;
-        
+
         // Overwrite decay thresholds to always trigger decay
         topk.decay_thresholds.iter_mut().for_each(|threshold| {
             *threshold = u64::MAX; // Always trigger decay
         });
-        
+
         topk.add(&item1, large_count);
-        
+
         // Verify the initial count
         assert_eq!(topk.count(&item1), large_count);
-        
+
         // Add item2 multiple times to trigger decay on item1
         let decay_iterations = 1000;
         let mut last_count = topk.bucket_count(&item1);
@@ -1103,10 +1224,16 @@ mod tests {
             let new_count = topk.bucket_count(&item1);
             if new_count == 0 {
                 // Item has been evicted
-                assert!(!topk.query(&item1), "item1 should be evicted if count is zero");
+                assert!(
+                    !topk.query(&item1),
+                    "item1 should be evicted if count is zero"
+                );
                 break;
             } else {
-                assert!(new_count < last_count, "Bucket count should decrease with each decay");
+                assert!(
+                    new_count < last_count,
+                    "Bucket count should decrease with each decay"
+                );
                 last_count = new_count;
             }
         }
@@ -1115,9 +1242,7 @@ mod tests {
     #[test]
     fn test_decay_and_eviction() {
         let mut mock_rng = MockRngCoreTrait::new();
-        mock_rng.expect_next_u64()
-            .times(1..)
-            .return_const(0u64);
+        mock_rng.expect_next_u64().times(1..).return_const(0u64);
 
         let topk = TopK::<Vec<u8>>::builder()
             .k(1)
@@ -1140,13 +1265,13 @@ mod tests {
         let start_count = 10;
         topk.add(&item1, start_count);
         assert_eq!(topk.count(&item1), start_count);
-        
+
         // Print fingerprints
         let fp1 = crate::hash_composition::HashComposer::new(&topk.hasher, &item1).fingerprint();
         let fp2 = crate::hash_composition::HashComposer::new(&topk.hasher, &item2).fingerprint();
         println!("item1 fingerprint: {}", fp1);
         println!("item2 fingerprint: {}", fp2);
-        
+
         println!("Initial state:");
         println!("  item1 count: {}", topk.count(&item1));
         println!("  item1 query: {}", topk.query(&item1));
@@ -1159,31 +1284,49 @@ mod tests {
         topk.add(&item2, 1);
         let after = topk.bucket_count(&item1);
         println!("After adding item2: item1 bucket count = {}", after);
-        
+
         println!("Final state:");
         println!("  item1 count: {}", topk.count(&item1));
         println!("  item1 query: {}", topk.query(&item1));
         println!("  item2 count: {}", topk.count(&item2));
         println!("  item2 query: {}", topk.query(&item2));
-        
+
         // After the first decay, item1's bucket count should be decremented by 1
-        assert_eq!(after, before - 1, "Bucket count should decrement by 1 after first decay");
-        
+        assert_eq!(
+            after,
+            before - 1,
+            "Bucket count should decrement by 1 after first decay"
+        );
+
         // Since the count is still > 0, item1 should still be in the bucket
         // and item2 should not have taken over the bucket
-        assert!(topk.query(&item1), "Item1 should still be in the bucket after decay");
-        assert_eq!(topk.bucket_count(&item1), 9, "Item1 bucket count should be 9 after decay");
+        assert!(
+            topk.query(&item1),
+            "Item1 should still be in the bucket after decay"
+        );
+        assert_eq!(
+            topk.bucket_count(&item1),
+            9,
+            "Item1 bucket count should be 9 after decay"
+        );
         assert!(!topk.query(&item2), "Item2 should not be in the bucket yet");
-        assert_eq!(topk.bucket_count(&item2), 0, "Item2 bucket count should still be 0");
-        
+        assert_eq!(
+            topk.bucket_count(&item2),
+            0,
+            "Item2 bucket count should still be 0"
+        );
+
         // Now add item2 again to trigger another decay
         topk.add(&item2, 1);
         let final_count = topk.bucket_count(&item1);
         println!("After second decay: item1 bucket count = {}", final_count);
-        
+
         // After multiple decays, item1 should eventually be evicted
         // For this test, we'll just verify the count continues to decrease
-        assert!(final_count < 9, "Item1 bucket count should continue to decrease with more decays");
+        assert!(
+            final_count < 9,
+            "Item1 bucket count should continue to decrease with more decays"
+        );
     }
 
     #[test]
@@ -1197,11 +1340,7 @@ mod tests {
         assert!(matches!(result, Err(BuilderError::MissingField { field }) if field == "k"));
 
         // Test missing width
-        let result = TopK::<Vec<u8>>::builder()
-            .k(10)
-            .depth(5)
-            .decay(0.9)
-            .build();
+        let result = TopK::<Vec<u8>>::builder().k(10).depth(5).decay(0.9).build();
         assert!(matches!(result, Err(BuilderError::MissingField { field }) if field == "width"));
 
         // Test missing depth
@@ -1213,25 +1352,21 @@ mod tests {
         assert!(matches!(result, Err(BuilderError::MissingField { field }) if field == "depth"));
 
         // Test missing decay
-        let result = TopK::<Vec<u8>>::builder()
-            .k(10)
-            .width(100)
-            .depth(5)
-            .build();
+        let result = TopK::<Vec<u8>>::builder().k(10).width(100).depth(5).build();
         assert!(matches!(result, Err(BuilderError::MissingField { field }) if field == "decay"));
     }
 
     #[test]
     fn test_send_sync_issue() {
-        use std::sync::{Arc, Mutex};
         use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
         use std::thread;
-        
+
         type Id = String;
         type IdTopK = Arc<Mutex<HashMap<Id, TopK<String>>>>;
-        
+
         let topk_map: IdTopK = Arc::new(Mutex::new(HashMap::new()));
-        
+
         thread::spawn(move || {
             let mut map = topk_map.lock().unwrap();
             let topk = TopK::new(10, 100, 5, 0.9);
@@ -1253,6 +1388,22 @@ mod tests {
         topk.add(item, 1);
         assert!(topk.query(item));
         assert_eq!(topk.count(item), 1);
+    }
+
+    #[test]
+    fn test_decay_threshold_no_usize_truncation_for_large_count() {
+        // On 32-bit targets, `count as usize` would truncate u64 counts
+        // greater than u32::MAX, returning a large threshold from the
+        // start of the lookup table instead of a tiny one. Verify that
+        // for counts > u32::MAX the returned threshold is effectively zero
+        // (decay^4_billion underflows to ~0).
+        let topk: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
+        let huge: u64 = (u32::MAX as u64) + 5000;
+        let thr = topk.decay_threshold_for_test(huge);
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
     }
 
     /// Tests that decay probability scaling uses the full u64 range
@@ -1299,4 +1450,3 @@ mod tests {
         assert_eq!(topk.bucket_count(&item2), 1);
     }
 }
-

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -328,10 +328,12 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         let tbl = &self.decay_thresholds;
         let last = tbl[tbl.len() - 1] as f64 / u64::MAX as f64;
         let divisor = (tbl.len() - 1) as u64;
-        let q = count / divisor;
+        // q is u64 — use powf(q as f64) instead of powi(q as i32) which
+        // would truncate (not saturate) for q > i32::MAX.
+        let q = (count / divisor) as f64;
         let r = (count % divisor) as usize;
         let rem_thr = tbl[r] as f64 / u64::MAX as f64;
-        ((last.powi(q as i32) * rem_thr) * u64::MAX as f64) as u64
+        ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 
     pub fn list(&self) -> Vec<TopKNode<T>> {
@@ -1399,6 +1401,20 @@ mod tests {
         // (decay^4_billion underflows to ~0).
         let topk: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
         let huge: u64 = (u32::MAX as u64) + 5000;
+        let thr = topk.decay_threshold_for_test(huge);
+        assert!(
+            thr < u64::MAX / 2,
+            "expected ~0 threshold for huge count, got {thr}"
+        );
+    }
+
+    #[test]
+    fn test_decay_threshold_no_powi_i32_overflow_for_huge_count() {
+        // `q = count / 1023` past i32::MAX would truncate (not saturate)
+        // to a negative i32; `powi(neg)` of a fractional base diverges
+        // and the threshold saturates to u64::MAX. Use powf instead.
+        let topk: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
+        let huge: u64 = (i32::MAX as u64) * 2048;
         let thr = topk.decay_threshold_for_test(huge);
         assert!(
             thr < u64::MAX / 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,14 @@
 //! by Junzhi Gong, Tong Yang, Haowei Zhang, and Hao Li, Peking University; Steve Uhlig, Queen Mary, University of London;
 //! Shigang Chen, University of Florida; Lorna Uden, Staffordshire University; Xiaoming Li, Peking University
 
-
 mod heavykeeper;
-pub use heavykeeper::TopK;
+pub use heavykeeper::{TopK, TopKNode};
 
 mod bucketed;
-pub use bucketed::{BucketedTopK, BucketedMergeError, BucketedBuilderError};
+pub use bucketed::{BucketedBuilderError, BucketedMergeError, BucketedNode, BucketedTopK};
 
-mod priority_queue;
+mod cuckoo;
+pub use cuckoo::{CuckooBuilderError, CuckooMergeError, CuckooNode, CuckooTopK};
+
 mod hash_composition;
+mod priority_queue;

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -1,14 +1,14 @@
+use ahash::RandomState;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::Hash;
-use ahash::RandomState;
 
 /// A specialized priority queue for HeavyKeeper that maintains top-k items by count
 pub(crate) struct TopKQueue<T> {
-    items: HashMap<T, (u64, usize), RandomState>,  // item -> (count, heap_index)
-    heap: Vec<(u64, usize, usize)>,  // (count, sequence, item_index)
-    item_store: Vec<T>,  // Store actual items here
-    free_slots: Vec<usize>,  // Track free slots in item_store
+    items: HashMap<T, (u64, usize), RandomState>, // item -> (count, heap_index)
+    heap: Vec<(u64, usize, usize)>,               // (count, sequence, item_index)
+    item_store: Vec<T>,                           // Store actual items here
+    free_slots: Vec<usize>,                       // Track free slots in item_store
     capacity: usize,
     sequence: usize,
 }
@@ -51,7 +51,9 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     {
         if let Some((old_count, pos)) = self.items.get_mut(item) {
             debug_assert!(count >= *old_count, "update_if_present must not decrease");
-            if count == *old_count { return true; }
+            if count == *old_count {
+                return true;
+            }
             *old_count = count;
             let pos = *pos;
             self.heap[pos].0 = count;
@@ -75,9 +77,11 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     pub(crate) fn upsert(&mut self, item: T, count: u64) {
         // Fast path: update existing item
         if let Some((old_count, pos)) = self.items.get_mut(&item) {
-            if count == *old_count { return; }
+            if count == *old_count {
+                return;
+            }
             *old_count = count;
-            
+
             // Update heap - no need to clone item
             let pos = *pos;
             let item_idx = self.heap[pos].2;
@@ -91,7 +95,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         if self.len() < self.capacity {
             let pos = self.heap.len();
             self.sequence += 1;
-            
+
             // Store item once
             let item_idx = if let Some(idx) = self.free_slots.pop() {
                 self.item_store[idx] = item.clone();
@@ -100,7 +104,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
                 self.item_store.push(item.clone());
                 self.item_store.len() - 1
             };
-            
+
             self.heap.push((count, self.sequence, item_idx));
             self.items.insert(item, (count, pos));
             self.sift_up(pos);
@@ -112,7 +116,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
             if count > min_count {
                 let old_item = &self.item_store[item_idx];
                 self.items.remove(old_item);
-                
+
                 // Reuse the item slot
                 self.item_store[item_idx] = item.clone();
                 self.items.insert(item, (count, 0));
@@ -146,9 +150,15 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     }
 
     // Binary heap helper methods using Eytzinger layout (0-based indexing)
-    fn parent(i: usize) -> usize { (i - 1) >> 1 }
-    fn left(i: usize) -> usize { 2 * i + 1 }
-    fn right(i: usize) -> usize { 2 * i + 2 }
+    fn parent(i: usize) -> usize {
+        (i - 1) >> 1
+    }
+    fn left(i: usize) -> usize {
+        2 * i + 1
+    }
+    fn right(i: usize) -> usize {
+        2 * i + 2
+    }
 
     fn sift_up(&mut self, mut pos: usize) {
         while pos > 0 {
@@ -189,11 +199,11 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         // Update indices in items map
         let (_, _, item_idx_i) = self.heap[i];
         let (_, _, item_idx_j) = self.heap[j];
-        
+
         // Get references to the actual items
         let item_i = &self.item_store[item_idx_i];
         let item_j = &self.item_store[item_idx_j];
-        
+
         // Update the positions in the items map
         if let Some((_, pos_i)) = self.items.get_mut(item_i) {
             *pos_i = i;
@@ -213,7 +223,7 @@ mod tests {
         let mut queue = TopKQueue::with_capacity(2);
         queue.upsert("a", 1);
         queue.upsert("b", 2);
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"b", 2), (&"a", 1)]);
     }
@@ -224,7 +234,7 @@ mod tests {
         queue.upsert("a", 1);
         queue.upsert("b", 2);
         queue.upsert("a", 3); // Update a's count
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"a", 3), (&"b", 2)]);
     }
@@ -232,22 +242,22 @@ mod tests {
     #[test]
     fn test_heap_cleanup() {
         let mut queue = TopKQueue::with_capacity_and_hasher(2, RandomState::new());
-        
+
         // Insert initial items
         queue.upsert("a", 1);
         queue.upsert("b", 2);
-        
+
         // Update 'a' multiple times
         queue.upsert("a", 3);
         queue.upsert("a", 4);
         queue.upsert("a", 5);
-        
+
         // Insert new item with higher count
         queue.upsert("c", 6);
-        
+
         // Check heap size vs items size
         assert_eq!(queue.heap.len(), 2, "Expected 2 items");
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"c", 6), (&"a", 5)]);
     }
@@ -255,12 +265,12 @@ mod tests {
     #[test]
     fn test_insertion_order() {
         let mut queue = TopKQueue::with_capacity_and_hasher(3, RandomState::new());
-        
+
         // Insert items with same count in specific order
         queue.upsert("a", 1);
         queue.upsert("b", 1);
         queue.upsert("c", 1);
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"a", 1), (&"b", 1), (&"c", 1)]);
     }
@@ -268,19 +278,19 @@ mod tests {
     #[test]
     fn test_heap_consistency() {
         let mut queue = TopKQueue::with_capacity_and_hasher(2, RandomState::new());
-        
+
         // Fill queue
         queue.upsert("a", 1);
         queue.upsert("b", 2);
-        
+
         // Update existing item multiple times
         for i in 3..10 {
             queue.upsert("a", i);
         }
-        
+
         // Try to insert new item
         queue.upsert("c", 5);
-        
+
         // Verify min_count is accurate
         assert_eq!(queue.min_count(), 5);
     }
@@ -288,16 +298,16 @@ mod tests {
     #[test]
     fn test_capacity_overflow() {
         let mut queue = TopKQueue::with_capacity_and_hasher(2, RandomState::new());
-        
+
         // Insert more items than capacity
         queue.upsert("a", 1);
         queue.upsert("b", 2);
         queue.upsert("c", 3);
         queue.upsert("d", 4);
         queue.upsert("e", 5);
-        
+
         assert_eq!(queue.len(), 2, "Queue should maintain capacity");
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"e", 5), (&"d", 4)]);
     }
@@ -305,16 +315,16 @@ mod tests {
     #[test]
     fn test_repeated_updates() {
         let mut queue = TopKQueue::with_capacity_and_hasher(2, RandomState::new());
-        
+
         // Insert and update same item repeatedly
         for i in 1..100 {
             queue.upsert("a", i);
         }
-        
+
         queue.upsert("b", 50);
-        
+
         assert_eq!(queue.len(), 2);
-        
+
         let items: Vec<_> = queue.iter().collect();
         assert_eq!(items, vec![(&"a", 99), (&"b", 50)]);
     }
@@ -322,28 +332,37 @@ mod tests {
     #[test]
     fn test_heap_property() {
         let mut queue = TopKQueue::with_capacity_and_hasher(10, RandomState::new());
-        
+
         // Insert in reverse order to test heap maintenance
         for i in (0..=10).rev() {
             queue.upsert(format!("item{}", i), i as u64);
         }
-        
+
         // Verify heap property: parent should be <= children for min-heap
         for i in 1..queue.heap.len() {
             let parent_idx = TopKQueue::<String>::parent(i);
-            if parent_idx > 0 {  // Skip root's parent
-                assert!(queue.heap[parent_idx].0 <= queue.heap[i].0, 
-                    "Heap property violated: parent count {} at index {} is greater than child count {} at index {}", 
-                    queue.heap[parent_idx].0, parent_idx, queue.heap[i].0, i);
+            if parent_idx > 0 {
+                // Skip root's parent
+                assert!(
+                    queue.heap[parent_idx].0 <= queue.heap[i].0,
+                    "Heap property violated: parent count {} at index {} is greater than child count {} at index {}",
+                    queue.heap[parent_idx].0,
+                    parent_idx,
+                    queue.heap[i].0,
+                    i
+                );
             }
         }
-        
+
         // Verify items are stored in descending order (highest counts first)
         let items: Vec<_> = queue.iter().collect();
-        for i in 0..items.len()-1 {
-            assert!(items[i].1 >= items[i+1].1, 
-                "Items not properly ordered by count: {} before {}", 
-                items[i].1, items[i+1].1);
+        for i in 0..items.len() - 1 {
+            assert!(
+                items[i].1 >= items[i + 1].1,
+                "Items not properly ordered by count: {} before {}",
+                items[i].1,
+                items[i + 1].1
+            );
         }
     }
-} 
+}

--- a/tests/accuracy_compare.rs
+++ b/tests/accuracy_compare.rs
@@ -1,12 +1,13 @@
-//! Side-by-side accuracy: canonical `TopK` vs `BucketedTopK`.
-//! Metrics: Top-K Hit Ratio and Average Relative Error (HeavyKeeper paper).
+//! Side-by-side accuracy: canonical `TopK` vs `BucketedTopK` vs `CuckooTopK`.
+//! Metrics: Top-K Hit Ratio plus paper-style heavy-hitter precision,
+//! recall, and Average Relative Error.
 //! Run with `cargo test --test accuracy_compare --release -- --nocapture`.
 
 use std::collections::{HashMap, HashSet};
 
-use heavykeeper::{BucketedTopK, TopK};
-use rand::SeedableRng;
+use heavykeeper::{BucketedTopK, CuckooTopK, TopK};
 use rand::rngs::StdRng;
+use rand::SeedableRng;
 use rand_distr::{Distribution, Zipf};
 
 const ZIPF_N: f64 = 1_000_000.0;
@@ -18,10 +19,25 @@ const DEPTH: usize = 4;
 const DECAY: f64 = 0.9;
 const SEED: u64 = 0xACC04ACC;
 
+const PAPER_STREAM_LEN: usize = 1_000_000;
+const PAPER_K: usize = 512;
+const PAPER_PHI: f64 = 0.0005;
+const PAPER_WIDTH: usize = 256;
+const PAPER_DEPTH: usize = 4;
+const PAPER_DECAY: f64 = 0.9;
+
 fn gen_zipf(s: f64, seed: u64) -> Vec<u64> {
     let mut rng = StdRng::seed_from_u64(seed);
     let dist = Zipf::new(ZIPF_N, s).expect("valid zipf");
-    (0..STREAM_LEN).map(|_| dist.sample(&mut rng) as u64).collect()
+    (0..STREAM_LEN)
+        .map(|_| dist.sample(&mut rng) as u64)
+        .collect()
+}
+
+fn gen_zipf_len(len: usize, s: f64, seed: u64) -> Vec<u64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let dist = Zipf::new(ZIPF_N, s).expect("valid zipf");
+    (0..len).map(|_| dist.sample(&mut rng) as u64).collect()
 }
 
 fn ground_truth(stream: &[u64]) -> HashMap<u64, u64> {
@@ -39,9 +55,24 @@ fn true_top_k(truth: &HashMap<u64, u64>) -> Vec<(u64, u64)> {
     v
 }
 
+fn true_heavy_hitters(truth: &HashMap<u64, u64>, threshold: u64) -> HashSet<u64> {
+    truth
+        .iter()
+        .filter_map(|(item, count)| (*count >= threshold).then_some(*item))
+        .collect()
+}
+
 struct Metrics {
     hit_ratio: f64,
     are: f64,
+}
+
+struct PaperMetrics {
+    precision: f64,
+    recall: f64,
+    are: f64,
+    reported: usize,
+    true_heavy_hitters: usize,
 }
 
 fn metrics_topk(stream: &[u64], truth: &HashMap<u64, u64>, true_set: &HashSet<u64>) -> Metrics {
@@ -60,6 +91,14 @@ fn metrics_bucketed(stream: &[u64], truth: &HashMap<u64, u64>, true_set: &HashSe
     score(&sketch.list(), truth, true_set, |n| (n.item, n.count))
 }
 
+fn metrics_cuckoo(stream: &[u64], truth: &HashMap<u64, u64>, true_set: &HashSet<u64>) -> Metrics {
+    let mut sketch: CuckooTopK<u64> = CuckooTopK::with_seed(K, WIDTH, DEPTH, DECAY, 12345);
+    for k in stream {
+        sketch.add(k, 1);
+    }
+    score(&sketch.list(), truth, true_set, |n| (n.item, n.count))
+}
+
 fn score<N>(
     reported: &[N],
     truth: &HashMap<u64, u64>,
@@ -67,7 +106,10 @@ fn score<N>(
     extract: impl Fn(&N) -> (u64, u64),
 ) -> Metrics {
     let pairs: Vec<(u64, u64)> = reported.iter().map(&extract).collect();
-    let hits = pairs.iter().filter(|(item, _)| true_set.contains(item)).count();
+    let hits = pairs
+        .iter()
+        .filter(|(item, _)| true_set.contains(item))
+        .count();
     let hit_ratio = hits as f64 / K as f64;
 
     // ARE skips false positives — true count of 0 has no meaningful ratio.
@@ -85,7 +127,54 @@ fn score<N>(
     Metrics { hit_ratio, are }
 }
 
-fn run_case(s: f64) -> (Metrics, Metrics) {
+fn score_paper_metrics(
+    reported: Vec<(u64, u64)>,
+    truth: &HashMap<u64, u64>,
+    true_set: &HashSet<u64>,
+    threshold: u64,
+    estimate: impl Fn(u64) -> u64,
+) -> PaperMetrics {
+    let reported_set: HashSet<u64> = reported
+        .into_iter()
+        .filter_map(|(item, estimate)| (estimate >= threshold).then_some(item))
+        .collect();
+
+    let hits = reported_set.intersection(true_set).count();
+    let precision = if reported_set.is_empty() {
+        0.0
+    } else {
+        hits as f64 / reported_set.len() as f64
+    };
+    let recall = if true_set.is_empty() {
+        0.0
+    } else {
+        hits as f64 / true_set.len() as f64
+    };
+
+    let relative_error_sum = true_set
+        .iter()
+        .map(|item| {
+            let true_count = truth[item];
+            let estimated_count = estimate(*item);
+            true_count.abs_diff(estimated_count) as f64 / true_count as f64
+        })
+        .sum::<f64>();
+    let are = if true_set.is_empty() {
+        0.0
+    } else {
+        relative_error_sum / true_set.len() as f64
+    };
+
+    PaperMetrics {
+        precision,
+        recall,
+        are,
+        reported: reported_set.len(),
+        true_heavy_hitters: true_set.len(),
+    }
+}
+
+fn run_case(s: f64) -> (Metrics, Metrics, Metrics) {
     let stream = gen_zipf(s, SEED);
     let truth = ground_truth(&stream);
     let true_top = true_top_k(&truth);
@@ -93,6 +182,7 @@ fn run_case(s: f64) -> (Metrics, Metrics) {
 
     let m_topk = metrics_topk(&stream, &truth, &true_set);
     let m_bkt = metrics_bucketed(&stream, &truth, &true_set);
+    let m_ck = metrics_cuckoo(&stream, &truth, &true_set);
 
     println!(
         "  Zipf s={s:<5}  TopK         hit_ratio={:.4}  ARE={:.6}",
@@ -102,8 +192,12 @@ fn run_case(s: f64) -> (Metrics, Metrics) {
         "  Zipf s={s:<5}  BucketedTopK hit_ratio={:.4}  ARE={:.6}",
         m_bkt.hit_ratio, m_bkt.are
     );
+    println!(
+        "  Zipf s={s:<5}  CuckooTopK   hit_ratio={:.4}  ARE={:.6}",
+        m_ck.hit_ratio, m_ck.are
+    );
 
-    (m_topk, m_bkt)
+    (m_topk, m_bkt, m_ck)
 }
 
 #[test]
@@ -114,22 +208,197 @@ fn compare_accuracy_zipf() {
     );
     println!();
 
-    let (t1, b1) = run_case(2.0);
-    assert!(t1.hit_ratio >= 0.80, "TopK s=2.0 hit_ratio {} < 0.80", t1.hit_ratio);
-    assert!(b1.hit_ratio >= 0.80, "BucketedTopK s=2.0 hit_ratio {} < 0.80", b1.hit_ratio);
+    let (t1, b1, c1) = run_case(2.0);
+    assert!(
+        t1.hit_ratio >= 0.80,
+        "TopK s=2.0 hit_ratio {} < 0.80",
+        t1.hit_ratio
+    );
+    assert!(
+        b1.hit_ratio >= 0.80,
+        "BucketedTopK s=2.0 hit_ratio {} < 0.80",
+        b1.hit_ratio
+    );
+    assert!(
+        c1.hit_ratio >= 0.80,
+        "CuckooTopK s=2.0 hit_ratio {} < 0.80",
+        c1.hit_ratio
+    );
 
-    let (t2, b2) = run_case(1.2);
-    assert!(t2.hit_ratio >= 0.50, "TopK s=1.2 hit_ratio {} < 0.50", t2.hit_ratio);
-    assert!(b2.hit_ratio >= 0.50, "BucketedTopK s=1.2 hit_ratio {} < 0.50", b2.hit_ratio);
+    let (t2, b2, c2) = run_case(1.2);
+    assert!(
+        t2.hit_ratio >= 0.50,
+        "TopK s=1.2 hit_ratio {} < 0.50",
+        t2.hit_ratio
+    );
+    assert!(
+        b2.hit_ratio >= 0.50,
+        "BucketedTopK s=1.2 hit_ratio {} < 0.50",
+        b2.hit_ratio
+    );
+    assert!(
+        c2.hit_ratio >= 0.50,
+        "CuckooTopK s=1.2 hit_ratio {} < 0.50",
+        c2.hit_ratio
+    );
 
-    let (t3, b3) = run_case(1.05);
-    assert!(t3.hit_ratio >= 0.20, "TopK s=1.05 hit_ratio {} < 0.20", t3.hit_ratio);
-    assert!(b3.hit_ratio >= 0.20, "BucketedTopK s=1.05 hit_ratio {} < 0.20", b3.hit_ratio);
+    let (t3, b3, c3) = run_case(1.05);
+    assert!(
+        t3.hit_ratio >= 0.20,
+        "TopK s=1.05 hit_ratio {} < 0.20",
+        t3.hit_ratio
+    );
+    assert!(
+        b3.hit_ratio >= 0.20,
+        "BucketedTopK s=1.05 hit_ratio {} < 0.20",
+        b3.hit_ratio
+    );
+    assert!(
+        c3.hit_ratio >= 0.20,
+        "CuckooTopK s=1.05 hit_ratio {} < 0.20",
+        c3.hit_ratio
+    );
 
     for (label, m) in [
-        ("TopK 2.0", &t1), ("BucketedTopK 2.0", &b1),
-        ("TopK 1.2", &t2), ("BucketedTopK 1.2", &b2),
+        ("TopK 2.0", &t1),
+        ("BucketedTopK 2.0", &b1),
+        ("CuckooTopK 2.0", &c1),
+        ("TopK 1.2", &t2),
+        ("BucketedTopK 1.2", &b2),
+        ("CuckooTopK 1.2", &c2),
     ] {
         assert!(m.are < 1.0, "{label} ARE {} >= 1.0", m.are);
     }
+}
+
+#[test]
+fn compare_paper_style_heavy_hitter_metrics() {
+    let stream = gen_zipf_len(PAPER_STREAM_LEN, 1.2, SEED);
+    let truth = ground_truth(&stream);
+    let threshold = (PAPER_PHI * PAPER_STREAM_LEN as f64).ceil() as u64;
+    let true_set = true_heavy_hitters(&truth, threshold);
+
+    assert!(
+        !true_set.is_empty(),
+        "paper-style test should generate at least one true heavy hitter"
+    );
+    assert!(
+        true_set.len() < PAPER_K,
+        "PAPER_K={PAPER_K} must exceed true heavy hitter count {} so recall is not heap-capped",
+        true_set.len()
+    );
+
+    let mut topk: TopK<u64> =
+        TopK::with_seed(PAPER_K, PAPER_WIDTH, PAPER_DEPTH, PAPER_DECAY, 12345);
+    let mut bucketed: BucketedTopK<u64> =
+        BucketedTopK::with_seed(PAPER_K, PAPER_WIDTH, PAPER_DEPTH, PAPER_DECAY, 12345);
+    let mut cuckoo: CuckooTopK<u64> =
+        CuckooTopK::with_seed(PAPER_K, PAPER_WIDTH, PAPER_DEPTH, PAPER_DECAY, 12345);
+    for item in &stream {
+        topk.add(item, 1);
+        bucketed.add(item, 1);
+        cuckoo.add(item, 1);
+    }
+
+    let topk_reported: Vec<_> = topk.list().into_iter().map(|n| (n.item, n.count)).collect();
+    let bucketed_reported: Vec<_> = bucketed
+        .list()
+        .into_iter()
+        .map(|n| (n.item, n.count))
+        .collect();
+    let cuckoo_reported: Vec<_> = cuckoo
+        .list()
+        .into_iter()
+        .map(|n| (n.item, n.count))
+        .collect();
+
+    let topk_metrics = score_paper_metrics(topk_reported, &truth, &true_set, threshold, |item| {
+        topk.count(&item)
+    });
+    let bucketed_metrics =
+        score_paper_metrics(bucketed_reported, &truth, &true_set, threshold, |item| {
+            bucketed.count(&item)
+        });
+    let cuckoo_metrics =
+        score_paper_metrics(cuckoo_reported, &truth, &true_set, threshold, |item| {
+            cuckoo.count(&item)
+        });
+
+    println!();
+    println!(
+        "Paper-style Zipf s=1.2: stream={PAPER_STREAM_LEN}, phi={PAPER_PHI}, threshold={threshold}, true_hh={}",
+        true_set.len()
+    );
+    println!(
+        "  TopK         precision={:.4} recall={:.4} ARE={:.6} reported={} true_hh={}",
+        topk_metrics.precision,
+        topk_metrics.recall,
+        topk_metrics.are,
+        topk_metrics.reported,
+        topk_metrics.true_heavy_hitters,
+    );
+    println!(
+        "  BucketedTopK precision={:.4} recall={:.4} ARE={:.6} reported={} true_hh={}",
+        bucketed_metrics.precision,
+        bucketed_metrics.recall,
+        bucketed_metrics.are,
+        bucketed_metrics.reported,
+        bucketed_metrics.true_heavy_hitters,
+    );
+    println!(
+        "  CuckooTopK precision={:.4} recall={:.4} ARE={:.6} reported={} true_hh={}",
+        cuckoo_metrics.precision,
+        cuckoo_metrics.recall,
+        cuckoo_metrics.are,
+        cuckoo_metrics.reported,
+        cuckoo_metrics.true_heavy_hitters,
+    );
+
+    assert!(
+        topk_metrics.precision >= 0.85,
+        "TopK precision {} < 0.85",
+        topk_metrics.precision
+    );
+    assert!(
+        topk_metrics.recall >= 0.75,
+        "TopK recall {} < 0.75",
+        topk_metrics.recall
+    );
+    assert!(
+        topk_metrics.are < 0.25,
+        "TopK ARE {} >= 0.25",
+        topk_metrics.are
+    );
+
+    assert!(
+        bucketed_metrics.precision >= 0.85,
+        "BucketedTopK precision {} < 0.85",
+        bucketed_metrics.precision
+    );
+    assert!(
+        bucketed_metrics.recall >= 0.75,
+        "BucketedTopK recall {} < 0.75",
+        bucketed_metrics.recall
+    );
+    assert!(
+        bucketed_metrics.are < 0.25,
+        "BucketedTopK ARE {} >= 0.25",
+        bucketed_metrics.are
+    );
+
+    assert!(
+        cuckoo_metrics.precision >= 0.85,
+        "CuckooTopK precision {} < 0.85",
+        cuckoo_metrics.precision
+    );
+    assert!(
+        cuckoo_metrics.recall >= 0.75,
+        "CuckooTopK recall {} < 0.75",
+        cuckoo_metrics.recall
+    );
+    assert!(
+        cuckoo_metrics.are < 0.25,
+        "CuckooTopK ARE {} >= 0.25",
+        cuckoo_metrics.are
+    );
 }


### PR DESCRIPTION
Cuckoo-hash HeavyKeeper with per-bucket lobby + non-decaying heavy slots and bounded kick chain. Adds builder, merge, and matches the TopK/BucketedTopK API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `CuckooTopK` sketch variant using cuckoo-style placement strategy for improved performance.
  * Added comprehensive comparison of three sketch implementations with performance and accuracy metrics.

* **Documentation**
  * Updated guide with new "Variants" section describing the three sketch options.
  * Added real-world packet trace performance benchmarks and guidance on variant selection.

* **Refactor**
  * Optimized bucket indexing for improved efficiency.
  * Enhanced decay threshold computation for large count values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pmcgleenon/heavykeeper-rs/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->