### PR TITLE
Dropping trait bound on fmt::Debug for crate main structs

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -90,7 +90,7 @@ fn precompute_decay_thresholds(decay: f64, num_entries: usize) -> Box<[u64]> {
         .into_boxed_slice()
 }
 
-pub struct BucketedTopK<T: Ord + Clone + Hash + Debug> {
+pub struct BucketedTopK<T: Ord + Clone + Hash> {
     width: usize,
     /// Non-zero when `width` is a power of two and `> 1`; in that case
     /// bucket indexing uses `hash & width_mask` instead of `% width`.
@@ -106,7 +106,7 @@ pub struct BucketedTopK<T: Ord + Clone + Hash + Debug> {
     top_items: usize,
 }
 
-impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
+impl<T: Ord + Clone + Hash> BucketedTopK<T> {
     pub fn new(k: usize, width: usize, depth: usize, decay: f64) -> Self {
         Self::with_seed(k, width, depth, decay, 12345)
     }
@@ -443,7 +443,7 @@ impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
 }
 
 #[cfg(test)]
-impl<T: Ord + Clone + Hash + Debug> BucketedTopK<T> {
+impl<T: Ord + Clone + Hash> BucketedTopK<T> {
     pub(crate) fn hasher(&self) -> &RandomState {
         &self.hasher
     }
@@ -463,13 +463,13 @@ pub struct BucketedBuilder<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T: Ord + Clone + Hash + Debug> Default for BucketedBuilder<T> {
+impl<T: Ord + Clone + Hash> Default for BucketedBuilder<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Ord + Clone + Hash + Debug> BucketedBuilder<T> {
+impl<T: Ord + Clone + Hash> BucketedBuilder<T> {
     pub fn new() -> Self {
         Self {
             k: None,

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -119,7 +119,7 @@ fn mix64(mut x: u64) -> u64 {
 /// candidate buckets (cuckoo-style); on collision the lower-count occupant
 /// is evicted and re-homed in its other candidate bucket via a bounded kick
 /// chain.
-pub struct CuckooTopK<T: Ord + Clone + Hash + Debug> {
+pub struct CuckooTopK<T: Ord + Clone + Hash> {
     width: usize,
     width_mask: usize,
     depth: usize,
@@ -135,7 +135,7 @@ pub struct CuckooTopK<T: Ord + Clone + Hash + Debug> {
     max_kicks: usize,
 }
 
-impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
+impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     /// Build a `CuckooTopK` with a fixed default seed and the default kick
     /// limit ([`DEFAULT_MAX_CUCKOO_KICKS`]). Parameters are not validated;
     /// use [`CuckooTopK::builder`] for a fallible, validated construction
@@ -722,13 +722,13 @@ pub struct CuckooBuilder<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T: Ord + Clone + Hash + Debug> Default for CuckooBuilder<T> {
+impl<T: Ord + Clone + Hash> Default for CuckooBuilder<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Ord + Clone + Hash + Debug> CuckooBuilder<T> {
+impl<T: Ord + Clone + Hash> CuckooBuilder<T> {
     pub fn new() -> Self {
         Self {
             k: None,
@@ -813,7 +813,7 @@ impl<T: Ord + Clone + Hash + Debug> CuckooBuilder<T> {
 }
 
 #[cfg(test)]
-impl<T: Ord + Clone + Hash + Debug> CuckooTopK<T> {
+impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     pub(crate) fn decay_threshold_for_test(&self, count: u64) -> u64 {
         self.decay_threshold(count)
     }

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -66,7 +66,7 @@ pub enum BuilderError {
     MissingField { field: String },
 }
 
-pub struct TopK<T: Ord + Clone + Hash + Debug> {
+pub struct TopK<T: Ord + Clone + Hash> {
     top_items: usize,
     width: usize,
     /// Non-zero when `width` is a power of two and `> 1`; the bucket
@@ -103,7 +103,7 @@ fn precompute_decay_thresholds(decay: f64, num_entries: usize) -> Vec<u64> {
     thresholds
 }
 
-impl<T: Ord + Clone + Hash + Debug> TopK<T> {
+impl<T: Ord + Clone + Hash> TopK<T> {
     pub fn builder() -> Builder<T> {
         Builder::new()
     }
@@ -349,42 +349,6 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
         nodes
     }
 
-    pub fn debug(&self) {
-        println!("width: {}", self.width);
-        println!("depth: {}", self.depth);
-        println!("decay: {}", self.decay);
-        println!("decay thresholds: {:?}", self.decay_thresholds);
-        let mut buckets: Vec<(&Bucket, usize, usize)> = self
-            .buckets
-            .iter()
-            .enumerate()
-            .flat_map(|(i, row)| {
-                row.iter()
-                    .enumerate()
-                    .map(move |(j, bucket)| (bucket, i, j))
-            })
-            .filter(|(bucket, _, _)| bucket.count != 0)
-            .collect();
-        buckets.sort_by(|a, b| b.0.count.cmp(&a.0.count));
-        for (bucket, i, j) in buckets {
-            println!("Bucket at row {}, column {}: {:?}", i, j, bucket);
-        }
-        println!("priority_queue: ");
-        let mut nodes = self
-            .priority_queue
-            .iter()
-            .map(|(item, count)| TopKNode {
-                item: item.clone(),
-                count,
-            })
-            .collect::<Vec<_>>();
-
-        nodes.sort();
-        for node in nodes {
-            println!("Node - Item: {:?}, Count: {}", node.item, node.count);
-        }
-    }
-
     // Merge another HeavyKeeper into this one
     pub fn merge(&mut self, other: &Self) -> Result<(), HeavyKeeperError> {
         // Verify compatible parameters
@@ -440,20 +404,56 @@ impl<T: Ord + Clone + Hash + Debug> TopK<T> {
     }
 }
 
-#[cfg(test)]
 impl<T: Ord + Clone + Hash + Debug> TopK<T> {
+    pub fn debug(&self) {
+        println!("width: {}", self.width);
+        println!("depth: {}", self.depth);
+        println!("decay: {}", self.decay);
+        println!("decay thresholds: {:?}", self.decay_thresholds);
+        let mut buckets: Vec<(&Bucket, usize, usize)> = self
+            .buckets
+            .iter()
+            .enumerate()
+            .flat_map(|(i, row)| {
+                row.iter()
+                    .enumerate()
+                    .map(move |(j, bucket)| (bucket, i, j))
+            })
+            .filter(|(bucket, _, _)| bucket.count != 0)
+            .collect();
+        buckets.sort_by(|a, b| b.0.count.cmp(&a.0.count));
+        for (bucket, i, j) in buckets {
+            println!("Bucket at row {}, column {}: {:?}", i, j, bucket);
+        }
+        println!("priority_queue: ");
+        let mut nodes = self
+            .priority_queue
+            .iter()
+            .map(|(item, count)| TopKNode {
+                item: item.clone(),
+                count,
+            })
+            .collect::<Vec<_>>();
+
+        nodes.sort();
+        for node in nodes {
+            println!("Node - Item: {:?}, Count: {}", node.item, node.count);
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn decay_threshold_for_test(&self, count: u64) -> u64 {
         self.decay_threshold(count)
     }
 }
 
-impl<T: Ord + Clone + Hash + Debug> Default for Builder<T> {
+impl<T: Ord + Clone + Hash> Default for Builder<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Ord + Clone + Hash + Debug> Builder<T> {
+impl<T: Ord + Clone + Hash> Builder<T> {
     pub fn new() -> Self {
         Self {
             k: None,


### PR DESCRIPTION
Hi @pmcgleenon, as discussed in #72 here is a PR dropping trait bound of all three major structs on `fmt::Debug`.

I just moved around `TopK::debug` to another `impl` block for the `fmt::Debug` bound but everything else is very straightforward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Relaxed generic trait constraints on core TopK data structures to increase flexibility and usability. The API now supports a broader range of custom types without requiring the `Debug` trait. All existing functionality is maintained, with debug features remaining available for types implementing debug support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pmcgleenon/heavykeeper-rs/pull/73)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->