### PR TITLE
feat: return evicted item from add

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -183,7 +183,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         let _ = self.add_with_evicted(item, increment);
     }
 
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<BucketedNode<T>>
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -248,7 +248,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
 
         let evicted = self.priority_queue.upsert(item.to_owned(), max_count);
         self.min_pq_count = self.priority_queue.min_count();
-        evicted.map(|(item, count)| BucketedNode { item, count })
+        evicted
     }
 
     pub fn count<Q>(&self, item: &Q) -> u64
@@ -1046,8 +1046,7 @@ mod tests {
         let evicted = topk
             .add_with_evicted(&b"c".to_vec(), 20)
             .expect("expected an eviction");
-        assert_eq!(evicted.item, b"a".to_vec());
-        assert_eq!(evicted.count, 5);
+        assert_eq!(evicted, b"a".to_vec());
 
         let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
         assert!(items.contains(&b"b".to_vec()));

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -180,8 +180,16 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
+        let _ = self.add_with_evicted(item, increment);
+    }
+
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<BucketedNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
         if increment == 0 {
-            return;
+            return None;
         }
         let h = self.hasher.hash_one(item);
         let fp = h;
@@ -222,10 +230,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
             self.decay_and_maybe_evict(bucket_start, min_idx, fp, increment)
         };
 
-        let max_count = match inserted {
-            Some(c) => c,
-            None => return,
-        };
+        let max_count = inserted?;
 
         // Paper Algorithm 1: heap value is max(maxv, existing_heap_value).
         // Item already in PQ → only raise; cell-decay must not drag PQ down.
@@ -234,15 +239,16 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
                 self.priority_queue.update_if_present(item, max_count);
                 self.min_pq_count = self.priority_queue.min_count();
             }
-            return;
+            return None;
         }
 
         if self.priority_queue.is_full() && max_count <= self.min_pq_count {
-            return;
+            return None;
         }
 
-        self.priority_queue.upsert(item.to_owned(), max_count);
+        let evicted = self.priority_queue.upsert(item.to_owned(), max_count);
         self.min_pq_count = self.priority_queue.min_count();
+        evicted.map(|(item, count)| BucketedNode { item, count })
     }
 
     pub fn count<Q>(&self, item: &Q) -> u64
@@ -1027,5 +1033,46 @@ mod tests {
                 .all(|n| n.item != b"new".to_vec() || n.count < 100),
             "new must not appear at heavy's count in top-k list"
         );
+    }
+
+    #[test]
+    fn test_add_with_evicted_returns_displaced_item() {
+        let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
+
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
+        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        assert_eq!(topk.list().len(), 2);
+
+        let evicted = topk
+            .add_with_evicted(&b"c".to_vec(), 20)
+            .expect("expected an eviction");
+        assert_eq!(evicted.item, b"a".to_vec());
+        assert_eq!(evicted.count, 5);
+
+        let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
+        assert!(items.contains(&b"b".to_vec()));
+        assert!(items.contains(&b"c".to_vec()));
+        assert!(!items.contains(&b"a".to_vec()));
+    }
+
+    #[test]
+    fn test_add_with_evicted_no_eviction_cases() {
+        let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
+
+        // increment == 0 → no work, no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+
+        // PQ not yet full → no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
+        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+
+        // Updating an already-tracked item → no eviction even at capacity.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+
+        // New item whose count cannot beat the PQ minimum → no eviction.
+        let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
+        topk.add_with_evicted(&b"hot".to_vec(), 50);
+        topk.add_with_evicted(&b"warm".to_vec(), 30);
+        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
     }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -230,8 +230,24 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
+        let _ = self.add_with_evicted(item, increment);
+    }
+
+    /// Same as [`add`], but returns the top-k entry that was displaced from
+    /// the priority queue by this call, if any. An eviction happens only
+    /// when the priority queue is at capacity and `item` reaches a count
+    /// strictly greater than the current minimum tracked count. Returns
+    /// `None` when nothing was evicted (queue not yet full, item already
+    /// tracked, or count too low to displace the current min).
+    ///
+    /// [`add`]: CuckooTopK::add
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<CuckooNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
         if increment == 0 {
-            return;
+            return None;
         }
 
         let fp = self.hasher.hash_one(item);
@@ -239,19 +255,16 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
 
         if let Some(idx) = self.find_heavy(fp, primary, alternate) {
             self.heavy[idx].count = self.heavy[idx].count.saturating_add(increment);
-            self.update_priority_queue(item, self.heavy[idx].count);
-            return;
+            return self.update_priority_queue(item, self.heavy[idx].count);
         }
 
-        let lobby_count = match self.update_lobby(primary, fp, increment) {
-            Some(count) => count,
-            None => return,
-        };
+        let lobby_count = self.update_lobby(primary, fp, increment)?;
 
         if self.promote(fp, lobby_count, primary, alternate) {
             self.clear_lobby(primary, fp);
-            self.update_priority_queue(item, lobby_count);
+            return self.update_priority_queue(item, lobby_count);
         }
+        None
     }
 
     /// Estimated count for `item`. Consults the priority queue first
@@ -689,7 +702,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 
-    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64)
+    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64) -> Option<CuckooNode<T>>
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -699,15 +712,16 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
                 self.priority_queue.update_if_present(item, count);
                 self.min_pq_count = self.priority_queue.min_count();
             }
-            return;
+            return None;
         }
 
         if self.priority_queue.is_full() && count <= self.min_pq_count {
-            return;
+            return None;
         }
 
-        self.priority_queue.upsert(item.to_owned(), count);
+        let evicted = self.priority_queue.upsert(item.to_owned(), count);
         self.min_pq_count = self.priority_queue.min_count();
+        evicted.map(|(item, count)| CuckooNode { item, count })
     }
 }
 
@@ -1261,5 +1275,60 @@ mod tests {
             thr < u64::MAX / 2,
             "expected ~0 threshold for huge count, got {thr}"
         );
+    }
+
+    #[test]
+    fn test_add_with_evicted_returns_displaced_item() {
+        // k=2 priority queue. Fill it with two items, then add a third
+        // hotter item. The minimum tracked item should be returned with
+        // its pre-eviction count.
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 64, 2, 0.9);
+
+        // Pump enough to force promotion into heavy slots so PQ gets
+        // populated.
+        let none1 = topk.add_with_evicted(&b"a".to_vec(), 5);
+        let none2 = topk.add_with_evicted(&b"b".to_vec(), 10);
+        assert!(none1.is_none(), "first add should not evict");
+        assert!(none2.is_none(), "second add (still under k) should not evict");
+
+        // Sanity-check both items reached the priority queue.
+        let list = topk.list();
+        assert_eq!(list.len(), 2);
+
+        // Adding a hotter third item should displace "a" (count 5).
+        let evicted = topk.add_with_evicted(&b"c".to_vec(), 20);
+        let evicted = evicted.expect("expected an eviction");
+        assert_eq!(evicted.item, b"a".to_vec());
+        assert_eq!(evicted.count, 5);
+
+        // PQ now holds b and c.
+        let list = topk.list();
+        let items: Vec<_> = list.iter().map(|n| n.item.clone()).collect();
+        assert!(items.contains(&b"b".to_vec()));
+        assert!(items.contains(&b"c".to_vec()));
+        assert!(!items.contains(&b"a".to_vec()));
+    }
+
+    #[test]
+    fn test_add_with_evicted_no_eviction_cases() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 64, 2, 0.9);
+
+        // increment == 0 → no work, no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+
+        // PQ not yet full → no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
+        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+
+        // Updating an already-tracked item → no eviction even at capacity.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+
+        // New item with count not high enough to beat the PQ minimum (5)
+        // → no eviction. Use a fresh sketch so heavy slots are free for
+        // promotion.
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 64, 2, 0.9);
+        topk.add_with_evicted(&b"hot".to_vec(), 50);
+        topk.add_with_evicted(&b"warm".to_vec(), 30);
+        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
     }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -233,7 +233,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         let _ = self.add_with_evicted(item, increment);
     }
 
-    /// Same as [`add`], but returns the top-k entry that was displaced from
+    /// Same as [`add`], but returns the top-k item that was displaced from
     /// the priority queue by this call, if any. An eviction happens only
     /// when the priority queue is at capacity and `item` reaches a count
     /// strictly greater than the current minimum tracked count. Returns
@@ -241,7 +241,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     /// tracked, or count too low to displace the current min).
     ///
     /// [`add`]: CuckooTopK::add
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<CuckooNode<T>>
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -702,7 +702,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 
-    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64) -> Option<CuckooNode<T>>
+    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64) -> Option<T>
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -721,7 +721,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
 
         let evicted = self.priority_queue.upsert(item.to_owned(), count);
         self.min_pq_count = self.priority_queue.min_count();
-        evicted.map(|(item, count)| CuckooNode { item, count })
+        evicted
     }
 }
 
@@ -1289,17 +1289,17 @@ mod tests {
         let none1 = topk.add_with_evicted(&b"a".to_vec(), 5);
         let none2 = topk.add_with_evicted(&b"b".to_vec(), 10);
         assert!(none1.is_none(), "first add should not evict");
-        assert!(none2.is_none(), "second add (still under k) should not evict");
+        assert!(
+            none2.is_none(),
+            "second add (still under k) should not evict"
+        );
 
         // Sanity-check both items reached the priority queue.
         let list = topk.list();
         assert_eq!(list.len(), 2);
-
-        // Adding a hotter third item should displace "a" (count 5).
         let evicted = topk.add_with_evicted(&b"c".to_vec(), 20);
         let evicted = evicted.expect("expected an eviction");
-        assert_eq!(evicted.item, b"a".to_vec());
-        assert_eq!(evicted.count, 5);
+        assert_eq!(evicted, b"a".to_vec());
 
         // PQ now holds b and c.
         let list = topk.list();

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -261,8 +261,8 @@ impl<T: Ord + Clone + Hash> TopK<T> {
     {
         let _ = self.add_with_evicted(item, increment);
     }
-    
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<TopKNode<T>>
+
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -326,9 +326,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         }
 
         // Clone the item here since we need to store it in the priority queue
-        self.priority_queue
-            .upsert(item.to_owned(), max_count)
-            .map(|(item, count)| TopKNode { item, count })
+        self.priority_queue.upsert(item.to_owned(), max_count)
     }
 
     fn decay_threshold(&self, count: u64) -> u64 {
@@ -1487,8 +1485,7 @@ mod tests {
         let evicted = topk
             .add_with_evicted(&b"c".to_vec(), 20)
             .expect("expected an eviction");
-        assert_eq!(evicted.item, b"a".to_vec());
-        assert_eq!(evicted.count, 5);
+        assert_eq!(evicted, b"a".to_vec());
 
         let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
         assert!(items.contains(&b"b".to_vec()));

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -259,8 +259,16 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
+        let _ = self.add_with_evicted(item, increment);
+    }
+    
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<TopKNode<T>>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
         if increment == 0 {
-            return;
+            return None;
         }
         let mut composer = HashComposer::new(&self.hasher, item);
         let mut max_count: u64 = 0;
@@ -310,15 +318,17 @@ impl<T: Ord + Clone + Hash> TopK<T> {
             if max_count > current {
                 self.priority_queue.update_if_present(item, max_count);
             }
-            return;
+            return None;
         }
 
         if self.priority_queue.is_full() && max_count <= self.priority_queue.min_count() {
-            return;
+            return None;
         }
 
         // Clone the item here since we need to store it in the priority queue
-        self.priority_queue.upsert(item.to_owned(), max_count);
+        self.priority_queue
+            .upsert(item.to_owned(), max_count)
+            .map(|(item, count)| TopKNode { item, count })
     }
 
     fn decay_threshold(&self, count: u64) -> u64 {
@@ -1464,5 +1474,46 @@ mod tests {
         // With correct scaling, item1 is fully decayed and replaced by item2.
         assert_eq!(topk.bucket_count(&item1), 0);
         assert_eq!(topk.bucket_count(&item2), 1);
+    }
+
+    #[test]
+    fn test_add_with_evicted_returns_displaced_item() {
+        let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
+
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
+        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        assert_eq!(topk.list().len(), 2);
+
+        let evicted = topk
+            .add_with_evicted(&b"c".to_vec(), 20)
+            .expect("expected an eviction");
+        assert_eq!(evicted.item, b"a".to_vec());
+        assert_eq!(evicted.count, 5);
+
+        let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
+        assert!(items.contains(&b"b".to_vec()));
+        assert!(items.contains(&b"c".to_vec()));
+        assert!(!items.contains(&b"a".to_vec()));
+    }
+
+    #[test]
+    fn test_add_with_evicted_no_eviction_cases() {
+        let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
+
+        // increment == 0 → no work, no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+
+        // PQ not yet full → no eviction.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
+        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+
+        // Updating an already-tracked item → no eviction even at capacity.
+        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+
+        // New item whose count cannot beat the PQ minimum → no eviction.
+        let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
+        topk.add_with_evicted(&b"hot".to_vec(), 50);
+        topk.add_with_evicted(&b"warm".to_vec(), 30);
+        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
     }
 }

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -118,11 +118,9 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         // Queue is full - check if new count beats minimum
         if let Some(&(min_count, _, item_idx)) = self.heap.first() {
             if count > min_count {
-                let old_item = self.item_store[item_idx].clone();
+                let old_item = std::mem::replace(&mut self.item_store[item_idx], item.clone());
                 self.items.remove(&old_item);
 
-                // Reuse the item slot
-                self.item_store[item_idx] = item.clone();
                 self.items.insert(item, (count, 0));
                 self.sequence += 1;
                 self.heap[0] = (count, self.sequence, item_idx);

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -76,10 +76,9 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
 
     /// Insert or update `item` to `count`.
     ///
-    /// Returns `Some((evicted, count))` when a previously tracked item is
-    /// displaced by this call (queue was full and `count` beat the current
-    /// min), otherwise `None`.
-    pub(crate) fn upsert(&mut self, item: T, count: u64) -> Option<(T, u64)> {
+    /// Returns `Some(evicted)` when a previously tracked item is displaced
+    /// by this call, otherwise `None`.
+    pub(crate) fn upsert(&mut self, item: T, count: u64) -> Option<T> {
         // Fast path: update existing item
         if let Some((old_count, pos)) = self.items.get_mut(&item) {
             if count == *old_count {
@@ -128,7 +127,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
                 self.sequence += 1;
                 self.heap[0] = (count, self.sequence, item_idx);
                 self.sift_down(0);
-                return Some((old_item, min_count));
+                return Some(old_item);
             }
         }
         None

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -74,11 +74,16 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len() >= self.capacity
     }
 
-    pub(crate) fn upsert(&mut self, item: T, count: u64) {
+    /// Insert or update `item` to `count`.
+    ///
+    /// Returns `Some((evicted, count))` when a previously tracked item is
+    /// displaced by this call (queue was full and `count` beat the current
+    /// min), otherwise `None`.
+    pub(crate) fn upsert(&mut self, item: T, count: u64) -> Option<(T, u64)> {
         // Fast path: update existing item
         if let Some((old_count, pos)) = self.items.get_mut(&item) {
             if count == *old_count {
-                return;
+                return None;
             }
             *old_count = count;
 
@@ -88,7 +93,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
             self.heap[pos] = (count, self.heap[pos].1, item_idx);
             self.sift_down(pos);
             self.sift_up(pos);
-            return;
+            return None;
         }
 
         // For new items, if we have space just add it
@@ -108,14 +113,14 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
             self.heap.push((count, self.sequence, item_idx));
             self.items.insert(item, (count, pos));
             self.sift_up(pos);
-            return;
+            return None;
         }
 
         // Queue is full - check if new count beats minimum
         if let Some(&(min_count, _, item_idx)) = self.heap.first() {
             if count > min_count {
-                let old_item = &self.item_store[item_idx];
-                self.items.remove(old_item);
+                let old_item = self.item_store[item_idx].clone();
+                self.items.remove(&old_item);
 
                 // Reuse the item slot
                 self.item_store[item_idx] = item.clone();
@@ -123,8 +128,10 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
                 self.sequence += 1;
                 self.heap[0] = (count, self.sequence, item_idx);
                 self.sift_down(0);
+                return Some((old_item, min_count));
             }
         }
+        None
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&T, u64)> {


### PR DESCRIPTION
## Summary

Adds `add_with_evicted` to `CuckooTopK`, `TopK`, and `BucketedTopK`. It behaves like `add` but returns the item that got pushed out of the top-k priority queue, so callers can react to "no-longer-hot" items (cache invalidation, external mirrors, events). `add` is unchanged.

## API

```rust
pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<Node<T>>
```

Returns `Some(node)` only when the queue is full and `item`'s count beats the current minimum, displacing it. Returns `None` otherwise (zero increment, queue not full, item already tracked, or count too low). `add` now just calls this and drops the result.

## Tests

2 tests per sketch (6 total) covering the eviction case and all `None` paths. All 101 lib tests pass. No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insertion APIs now optionally return the item displaced from the top‑k set when an eviction occurs.

* **Refactor**
  * Insertion and eviction flows standardized across top‑k implementations and the priority queue for consistent behavior and clearer return semantics.

* **Tests**
  * Added unit tests validating eviction returns and multiple no‑eviction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->