### PR TITLE
feat: add top-k membership checks

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -287,7 +287,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
     }
 
     /// Returns true if `item` is currently one of the top-k tracked flows.
-    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    pub fn contains_top_k<Q>(&self, item: &Q) -> bool
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -624,23 +624,23 @@ mod tests {
     }
 
     #[test]
-    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+    fn test_contains_top_k_distinguishes_tracked_from_sketch_only() {
         let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(1, 1, 1, 0.9);
 
         topk.add(b"hot".as_slice(), 100);
-        assert!(topk.query_topk_items(b"hot".as_slice()));
+        assert!(topk.contains_top_k(b"hot".as_slice()));
 
         topk.add(b"cold".as_slice(), 1);
-        assert!(!topk.query_topk_items(b"cold".as_slice()));
-        assert!(!topk.query_topk_items(b"absent".as_slice()));
+        assert!(!topk.contains_top_k(b"cold".as_slice()));
+        assert!(!topk.contains_top_k(b"absent".as_slice()));
     }
 
     #[test]
-    fn test_query_topk_items_borrowed_lookup() {
+    fn test_contains_top_k_borrowed_lookup() {
         let mut topk: BucketedTopK<String> = BucketedTopK::new(10, 100, 4, 0.9);
         topk.add("foo", 5);
-        assert!(topk.query_topk_items("foo"));
-        assert!(!topk.query_topk_items("bar"));
+        assert!(topk.contains_top_k("foo"));
+        assert!(!topk.contains_top_k("bar"));
     }
 
     #[test]

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -286,6 +286,15 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         self.count(item) > 0
     }
 
+    /// Returns true if `item` is currently one of the top-k tracked flows.
+    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.priority_queue.contains(item)
+    }
+
     pub fn list(&self) -> Vec<BucketedNode<T>> {
         let mut nodes: Vec<BucketedNode<T>> = self
             .priority_queue
@@ -612,6 +621,26 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].item, b"a".to_vec());
         assert_eq!(list[0].count, 5);
+    }
+
+    #[test]
+    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+        let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(1, 1, 1, 0.9);
+
+        topk.add(b"hot".as_slice(), 100);
+        assert!(topk.query_topk_items(b"hot".as_slice()));
+
+        topk.add(b"cold".as_slice(), 1);
+        assert!(!topk.query_topk_items(b"cold".as_slice()));
+        assert!(!topk.query_topk_items(b"absent".as_slice()));
+    }
+
+    #[test]
+    fn test_query_topk_items_borrowed_lookup() {
+        let mut topk: BucketedTopK<String> = BucketedTopK::new(10, 100, 4, 0.9);
+        topk.add("foo", 5);
+        assert!(topk.query_topk_items("foo"));
+        assert!(!topk.query_topk_items("bar"));
     }
 
     #[test]

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -319,9 +319,9 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     pub fn query_topk_items<Q>(&self, item: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+        Q: Hash + Eq + ?Sized,
     {
-        self.priority_queue.get(item).is_some()
+        self.priority_queue.contains(item)
     }
 
     /// Top-k items currently tracked by the priority queue, sorted by

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -316,7 +316,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     }
 
     /// Returns true if `item` is currently one of the top-k tracked flows
-    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    pub fn contains_top_k<Q>(&self, item: &Q) -> bool
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -1342,31 +1342,31 @@ mod tests {
     }
 
     #[test]
-    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+    fn test_contains_top_k_distinguishes_tracked_from_sketch_only() {
         let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(1, 1, 1, 0.9);
 
         topk.add(b"hot".as_slice(), 100);
         assert!(
-            topk.query_topk_items(b"hot".as_slice()),
+            topk.contains_top_k(b"hot".as_slice()),
             "hot is the tracked top-1"
         );
 
         // A weaker item: present in the sketch but not in the top-k.
         topk.add(b"cold".as_slice(), 1);
         assert!(
-            !topk.query_topk_items(b"cold".as_slice()),
+            !topk.contains_top_k(b"cold".as_slice()),
             "cold is not tracked in the top-k"
         );
 
         // An item never added at all is neither in the sketch nor top-k.
-        assert!(!topk.query_topk_items(b"absent".as_slice()));
+        assert!(!topk.contains_top_k(b"absent".as_slice()));
     }
 
     #[test]
-    fn test_query_topk_items_borrowed_lookup() {
+    fn test_contains_top_k_borrowed_lookup() {
         let mut topk: CuckooTopK<String> = CuckooTopK::new(10, 100, 4, 0.9);
         topk.add("foo", 5);
-        assert!(topk.query_topk_items("foo"));
-        assert!(!topk.query_topk_items("bar"));
+        assert!(topk.contains_top_k("foo"));
+        assert!(!topk.contains_top_k("bar"));
     }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -315,6 +315,15 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         self.count(item) > 0
     }
 
+    /// Returns true if `item` is currently one of the top-k tracked flows
+    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
+    {
+        self.priority_queue.get(item).is_some()
+    }
+
     /// Top-k items currently tracked by the priority queue, sorted by
     /// descending count. Items still in the lobby (not yet promoted to a
     /// heavy slot) do not appear here.
@@ -1330,5 +1339,34 @@ mod tests {
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
         assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
+    }
+
+    #[test]
+    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+        let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(1, 1, 1, 0.9);
+
+        topk.add(b"hot".as_slice(), 100);
+        assert!(
+            topk.query_topk_items(b"hot".as_slice()),
+            "hot is the tracked top-1"
+        );
+
+        // A weaker item: present in the sketch but not in the top-k.
+        topk.add(b"cold".as_slice(), 1);
+        assert!(
+            !topk.query_topk_items(b"cold".as_slice()),
+            "cold is not tracked in the top-k"
+        );
+
+        // An item never added at all is neither in the sketch nor top-k.
+        assert!(!topk.query_topk_items(b"absent".as_slice()));
+    }
+
+    #[test]
+    fn test_query_topk_items_borrowed_lookup() {
+        let mut topk: CuckooTopK<String> = CuckooTopK::new(10, 100, 4, 0.9);
+        topk.add("foo", 5);
+        assert!(topk.query_topk_items("foo"));
+        assert!(!topk.query_topk_items("bar"));
     }
 }

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -202,7 +202,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
     }
 
     /// Returns true if `item` is currently one of the top-k tracked flows.
-    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    pub fn contains_top_k<Q>(&self, item: &Q) -> bool
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -652,23 +652,23 @@ mod tests {
     }
 
     #[test]
-    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+    fn test_contains_top_k_distinguishes_tracked_from_sketch_only() {
         let mut topk: TopK<Vec<u8>> = TopK::new(1, 1, 1, 0.9);
 
         topk.add(b"hot".as_slice(), 100);
-        assert!(topk.query_topk_items(b"hot".as_slice()));
+        assert!(topk.contains_top_k(b"hot".as_slice()));
 
         topk.add(b"cold".as_slice(), 1);
-        assert!(!topk.query_topk_items(b"cold".as_slice()));
-        assert!(!topk.query_topk_items(b"absent".as_slice()));
+        assert!(!topk.contains_top_k(b"cold".as_slice()));
+        assert!(!topk.contains_top_k(b"absent".as_slice()));
     }
 
     #[test]
-    fn test_query_topk_items_borrowed_lookup() {
+    fn test_contains_top_k_borrowed_lookup() {
         let mut topk: TopK<String> = TopK::new(10, 100, 4, 0.9);
         topk.add("foo", 5);
-        assert!(topk.query_topk_items("foo"));
-        assert!(!topk.query_topk_items("bar"));
+        assert!(topk.contains_top_k("foo"));
+        assert!(!topk.contains_top_k("bar"));
     }
 
     /// Tests support for non-ASCII characters and emoji

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -201,6 +201,15 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         min_count != u64::MAX
     }
 
+    /// Returns true if `item` is currently one of the top-k tracked flows.
+    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.priority_queue.contains(item)
+    }
+    
     pub fn count<Q>(&self, item: &Q) -> u64
     where
         T: Borrow<Q>,
@@ -640,6 +649,26 @@ mod tests {
             1337,
             "Count should match number of additions"
         );
+    }
+
+    #[test]
+    fn test_query_topk_items_distinguishes_tracked_from_sketch_only() {
+        let mut topk: TopK<Vec<u8>> = TopK::new(1, 1, 1, 0.9);
+
+        topk.add(b"hot".as_slice(), 100);
+        assert!(topk.query_topk_items(b"hot".as_slice()));
+
+        topk.add(b"cold".as_slice(), 1);
+        assert!(!topk.query_topk_items(b"cold".as_slice()));
+        assert!(!topk.query_topk_items(b"absent".as_slice()));
+    }
+
+    #[test]
+    fn test_query_topk_items_borrowed_lookup() {
+        let mut topk: TopK<String> = TopK::new(10, 100, 4, 0.9);
+        topk.add("foo", 5);
+        assert!(topk.query_topk_items("foo"));
+        assert!(!topk.query_topk_items("bar"));
     }
 
     /// Tests support for non-ASCII characters and emoji

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -42,6 +42,14 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.get(item).map(|(count, _)| *count)
     }
 
+    pub(crate) fn contains<Q>(&self, item: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.items.contains_key(item)
+    }
+
     /// Increase an existing entry's count. Caller must guarantee the new count
     /// is >= the current count (paper Algorithm 1: heap is max(maxv, existing)).
     pub(crate) fn update_if_present<Q>(&mut self, item: &Q, count: u64) -> bool


### PR DESCRIPTION
## Summary

This PR introduces `query_topk_items()` for three top-k sketches, so callers can directly check whether an item is currently in the top-k items.

## Changes

- add `TopKQueue::contains()` for direct membership checks
- add `query_topk_items()` to `TopK`,`BucketedTopK` and `CuckooTopK`
```
    pub fn query_topk_items<Q>(&self, item: &Q) -> bool
    where
        T: Borrow<Q>,
        Q: Hash + Eq + ?Sized,
    {
        self.priority_queue.contains(item)
    }
```
## Testing
added unit tests for all three TopK variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a query to determine whether an item is actively tracked in top-k results (distinct from items present only in the sketch).
  * Added support for compatible-type (borrowed) lookups across top-k implementations (e.g., querying with string references).

* **Tests**
  * Added unit tests validating tracked-vs-sketch membership and borrowed-lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->