### PR TITLE
feat: derive Clone for all sketch types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ debug = true
 
 [dev-dependencies]
 criterion = "0.8.2"
-mockall = "0.14"
 clap = { version = "4.5.19", features = ["derive"] }
 memmap2 = "0.9.5"
 rand_distr = "0.5"

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -90,6 +90,7 @@ fn precompute_decay_thresholds(decay: f64, num_entries: usize) -> Box<[u64]> {
         .into_boxed_slice()
 }
 
+#[derive(Clone)]
 pub struct BucketedTopK<T: Ord + Clone + Hash> {
     width: usize,
     /// Non-zero when `width` is a power of two and `> 1`; in that case

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -119,6 +119,9 @@ fn mix64(mut x: u64) -> u64 {
 /// candidate buckets (cuckoo-style); on collision the lower-count occupant
 /// is evicted and re-homed in its other candidate bucket via a bounded kick
 /// chain.
+///
+/// Implements [`Clone`] as a true deep copy
+#[derive(Clone)]
 pub struct CuckooTopK<T: Ord + Clone + Hash> {
     width: usize,
     width_mask: usize,

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -66,6 +66,7 @@ pub enum BuilderError {
     MissingField { field: String },
 }
 
+#[derive(Clone)]
 pub struct TopK<T: Ord + Clone + Hash> {
     top_items: usize,
     width: usize,
@@ -78,7 +79,7 @@ pub struct TopK<T: Ord + Clone + Hash> {
     buckets: Vec<Vec<Bucket>>,
     priority_queue: TopKQueue<T>,
     hasher: RandomState,
-    random: Box<dyn RngCore + Send + Sync>,
+    random: SmallRng,
 }
 
 pub struct Builder<T> {
@@ -88,7 +89,6 @@ pub struct Builder<T> {
     decay: Option<f64>,
     seed: Option<u64>,
     hasher: Option<RandomState>,
-    rng: Option<Box<dyn RngCore + Send + Sync>>,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -127,14 +127,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         decay: f64,
         hasher: RandomState,
     ) -> Self {
-        Self::with_components(
-            k,
-            width,
-            depth,
-            decay,
-            hasher,
-            Box::new(SmallRng::seed_from_u64(0)),
-        )
+        Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(0))
     }
 
     fn with_components(
@@ -143,7 +136,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         depth: usize,
         decay: f64,
         hasher: RandomState,
-        rng: Box<dyn RngCore + Send + Sync>,
+        rng: SmallRng,
     ) -> Self {
         // Pre-allocate with capacity to avoid resizing
         let mut buckets = Vec::with_capacity(depth);
@@ -209,7 +202,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
     {
         self.priority_queue.contains(item)
     }
-    
+
     pub fn count<Q>(&self, item: &Q) -> u64
     where
         T: Borrow<Q>,
@@ -479,7 +472,6 @@ impl<T: Ord + Clone + Hash> Builder<T> {
             decay: None,
             seed: None,
             hasher: None,
-            rng: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -514,11 +506,6 @@ impl<T: Ord + Clone + Hash> Builder<T> {
         self
     }
 
-    pub fn rng<R: RngCore + Send + Sync + 'static>(mut self, rng: R) -> Self {
-        self.rng = Some(Box::new(rng));
-        self
-    }
-
     pub fn build(self) -> Result<TopK<T>, BuilderError> {
         let k = self.k.ok_or_else(|| BuilderError::MissingField {
             field: "k".to_string(),
@@ -541,13 +528,7 @@ impl<T: Ord + Clone + Hash> Builder<T> {
             }
         });
 
-        let rng = self.rng.unwrap_or_else(|| {
-            if let Some(seed) = self.seed {
-                Box::new(SmallRng::seed_from_u64(seed))
-            } else {
-                Box::new(SmallRng::seed_from_u64(0))
-            }
-        });
+        let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
 
         Ok(TopK::with_components(k, width, depth, decay, hasher, rng))
     }
@@ -556,31 +537,6 @@ impl<T: Ord + Clone + Hash> Builder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockall::automock;
-
-    #[automock]
-    trait RngCoreTrait {
-        fn next_u64(&mut self) -> u64;
-    }
-
-    impl RngCore for MockRngCoreTrait {
-        fn next_u32(&mut self) -> u32 {
-            RngCoreTrait::next_u64(self) as u32
-        }
-
-        fn next_u64(&mut self) -> u64 {
-            RngCoreTrait::next_u64(self)
-        }
-
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            for chunk in dest.chunks_mut(8) {
-                let value = RngCoreTrait::next_u64(self);
-                for (i, byte) in chunk.iter_mut().enumerate() {
-                    *byte = (value >> (i * 8)) as u8;
-                }
-            }
-        }
-    }
 
     /// Tests basic initialization of TopK with default parameters
     #[test]
@@ -1222,19 +1178,13 @@ mod tests {
     }
 
     #[test]
-    fn test_decay_logic_with_mock_rng() {
-        let mut mock_rng = MockRngCoreTrait::new();
-        mock_rng
-            .expect_next_u64()
-            .times(1..) // Allow multiple calls
-            .return_const(0u64);
-
+    fn test_decay_logic() {
         let topk = TopK::<Vec<u8>>::builder()
             .k(1)
             .width(1)
             .depth(1)
             .decay(0.9)
-            .rng(mock_rng)
+            .seed(12345)
             .build()
             .unwrap();
 
@@ -1280,15 +1230,12 @@ mod tests {
 
     #[test]
     fn test_decay_and_eviction() {
-        let mut mock_rng = MockRngCoreTrait::new();
-        mock_rng.expect_next_u64().times(1..).return_const(0u64);
-
         let topk = TopK::<Vec<u8>>::builder()
             .k(1)
             .width(1)
             .depth(1)
             .decay(0.9)
-            .rng(mock_rng)
+            .seed(12345)
             .build()
             .unwrap();
 
@@ -1461,30 +1408,22 @@ mod tests {
 
     /// Tests that decay probability scaling uses the full u64 range
     ///
-    /// With decay = 1.0 and RNG always returning exactly 2^63, the old
-    /// implementation (which used threshold = 2^63) would never decay
-    /// because `rand < threshold` was false for rand = 2^63.
-    ///
-    /// After the fix (threshold = u64::MAX), the same condition is true,
-    /// so the bucket is always decayed and replaced as expected for
-    /// probability 1.0.
+    /// The decay roll is `rng.next_u64() < threshold`. With decay = 1.0 the
+    /// threshold must span the full u64 range (`u64::MAX`) so that decay
+    /// fires for every possible RNG value.
     #[test]
     fn test_decay_probability_scaling_fix() {
-        let mut mock_rng = MockRngCoreTrait::new();
-        // Always return value exactly at the old threshold: 2^63.
-        mock_rng
-            .expect_next_u64()
-            .times(1..) // Allow multiple calls
-            .return_const(1u64 << 63);
-
         let mut topk = TopK::<Vec<u8>>::builder()
             .k(1)
             .width(1)
             .depth(1)
             .decay(1.0)
-            .rng(mock_rng)
+            .seed(12345)
             .build()
             .unwrap();
+
+        // decay = 1.0 -> full-range threshold (u64::MAX)
+        assert_eq!(topk.decay_threshold_for_test(5), u64::MAX);
 
         let item1 = b"item1".to_vec();
         let item2 = b"item2".to_vec();

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -117,7 +117,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
     // New constructor that takes a seed
     pub fn with_seed(k: usize, width: usize, depth: usize, decay: f64, seed: u64) -> Self {
         let hasher = RandomState::with_seeds(seed, seed, seed, seed);
-        Self::with_hasher(k, width, depth, decay, hasher)
+        Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(seed))
     }
 
     pub fn with_hasher(

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 /// A specialized priority queue for HeavyKeeper that maintains top-k items by count
+#[derive(Clone)]
 pub(crate) struct TopKQueue<T> {
     items: HashMap<T, (u64, usize), RandomState>, // item -> (count, heap_index)
     heap: Vec<(u64, usize, usize)>,               // (count, sequence, item_index)


### PR DESCRIPTION
## Summary

Adds `Clone` support to all three sketch types so a populated sketch can be deep-copied. Follow-up to #82.
- `TopK` — see breaking change below
- `BucketedTopK` — `#[derive(Clone)]`
- `CuckooTopK` — `#[derive(Clone)]` 


All backing storage is owned outright (`Box<[_]>` / `Vec`, no `Rc`/`Arc` sharing), and the hasher + RNG state are copied verbatim, so each derived `Clone` is a true deep copy.

## Breaking change (TopK only)
`TopK` previously held a `Box<dyn RngCore + Send + Sync>`, which can't be cloned. Per suggestion in the issue #82 , I swapped it for a concrete `SmallRng`.

This **removes the public `Builder::rng()` method**. Callers who relied on it for deterministic tests should use `Builder::seed()` instead. The three decay tests that injected a mock RNG were migrated to a fixed seed; the probability-scaling regression is now pinned by asserting `decay_threshold` directly. The now-unused `mockall` dev-dependency is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-K sketch types are now cloneable, making it easier to copy and reuse sketch instances.
* **Breaking Changes**
  * Custom random number generator injection via the builder API has been removed.
  * Builder behavior now relies on a built-in deterministic RNG seeded from the builder’s optional seed (defaulting to `0`).
* **Tests / Chores**
  * Updated the test suite to match the new builder RNG behavior and refreshed dependency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->