### PR TITLE
feat: add mem_bytes() memory estimation to all three sketches

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -309,6 +309,14 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         nodes
     }
 
+    /// Estimated heap memory (in bytes) used by this sketch.
+    pub fn mem_bytes(&self) -> usize {
+        use std::mem::size_of;
+        self.cells.len() * size_of::<Cell>()
+            + self.decay_thresholds.len() * size_of::<u64>()
+            + self.priority_queue.heap_size_bytes()
+    }
+
     /// Merge `other` into `self`. PQ merged first using pre-merge bucket
     /// counts as fallback; cells then unioned per bucket by fingerprint
     /// (min-count eviction on full buckets).

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -314,7 +314,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         use std::mem::size_of;
         self.cells.len() * size_of::<Cell>()
             + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.heap_size_bytes()
+            + self.priority_queue.mem_bytes()
     }
 
     /// Merge `other` into `self`. PQ merged first using pre-merge bucket
@@ -575,6 +575,30 @@ impl<T: Ord + Clone + Hash> BucketedBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_mem_bytes_covers_cells_and_decay_table() {
+        let topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 4, 0.9);
+        let cells = 100 * 4 * std::mem::size_of::<Cell>();
+        let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
+        // The fixed cell array and decay table are exact; the priority
+        // queue adds more on top.
+        assert!(topk.mem_bytes() >= cells + decay);
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_width() {
+        let small: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 4, 0.9);
+        let large: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 400, 4, 0.9);
+        assert!(large.mem_bytes() > small.mem_bytes());
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_depth() {
+        let shallow: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 2, 0.9);
+        let deep: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 8, 0.9);
+        assert!(deep.mem_bytes() > shallow.mem_bytes());
+    }
 
     #[test]
     fn test_new_default_params() {

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -376,7 +376,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         self.lobbies.len() * size_of::<Cell>()
             + self.heavy.len() * size_of::<Cell>()
             + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.heap_size_bytes()
+            + self.priority_queue.mem_bytes()
     }
 
     /// Merge `other` into `self`. Both sketches must share width, depth,
@@ -871,6 +871,31 @@ mod tests {
         assert_eq!(topk.top_items, 10);
         assert_eq!(topk.lobbies.len(), 64);
         assert_eq!(topk.heavy.len(), 192);
+    }
+
+    #[test]
+    fn test_mem_bytes_covers_cells_and_decay_table() {
+        let topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 3, 0.9);
+        let cell = std::mem::size_of::<Cell>();
+        let lobbies = 64 * cell;
+        let heavy = 64 * 3 * cell;
+        let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
+        // The fixed sketch arrays are exact; the priority queue adds more.
+        assert!(topk.mem_bytes() >= lobbies + heavy + decay);
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_width() {
+        let small: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 3, 0.9);
+        let large: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 256, 3, 0.9);
+        assert!(large.mem_bytes() > small.mem_bytes());
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_depth() {
+        let shallow: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 2, 0.9);
+        let deep: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 8, 0.9);
+        assert!(deep.mem_bytes() > shallow.mem_bytes());
     }
 
     #[test]

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -366,6 +366,19 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         self.max_kicks
     }
 
+    /// Estimated heap memory (in bytes) used by this sketch.
+    ///
+    /// Sums the lobby and heavy cell arrays, the precomputed decay-threshold
+    /// table, and the priority queue's allocations. This is an approximation:
+    /// it excludes heap owned by individual tracked `T` values                                                                        
+    pub fn mem_bytes(&self) -> usize {
+        use std::mem::size_of;
+        self.lobbies.len() * size_of::<Cell>()
+            + self.heavy.len() * size_of::<Cell>()
+            + self.decay_thresholds.len() * size_of::<u64>()
+            + self.priority_queue.heap_size_bytes()
+    }
+
     /// Merge `other` into `self`. Both sketches must share width, depth,
     /// decay, top_items and a compatible hasher (probe-checked at merge
     /// time). Heavy fingerprints from `other` are re-inserted into the

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -359,6 +359,21 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         nodes
     }
 
+    /// Estimated heap memory (in bytes) used by this sketch.
+    pub fn mem_bytes(&self) -> usize {
+        use std::mem::size_of;
+        let outer = self.buckets.capacity() * size_of::<Vec<Bucket>>();
+        let rows: usize = self
+            .buckets
+            .iter()
+            .map(|row| row.capacity() * size_of::<Bucket>())
+            .sum();
+        outer
+            + rows
+            + self.decay_thresholds.capacity() * size_of::<u64>()
+            + self.priority_queue.heap_size_bytes()
+    }
+
     // Merge another HeavyKeeper into this one
     pub fn merge(&mut self, other: &Self) -> Result<(), HeavyKeeperError> {
         // Verify compatible parameters

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -371,7 +371,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         outer
             + rows
             + self.decay_thresholds.capacity() * size_of::<u64>()
-            + self.priority_queue.heap_size_bytes()
+            + self.priority_queue.mem_bytes()
     }
 
     // Merge another HeavyKeeper into this one
@@ -552,6 +552,30 @@ impl<T: Ord + Clone + Hash> Builder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_mem_bytes_covers_rows_and_decay_table() {
+        let topk: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
+        let rows = 100 * 5 * std::mem::size_of::<Bucket>();
+        let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
+        // The per-row Bucket allocations and decay table are accounted for;
+        // the outer Vec and priority queue add more on top.
+        assert!(topk.mem_bytes() >= rows + decay);
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_width() {
+        let small: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
+        let large: TopK<Vec<u8>> = TopK::new(10, 400, 5, 0.9);
+        assert!(large.mem_bytes() > small.mem_bytes());
+    }
+
+    #[test]
+    fn test_mem_bytes_grows_with_depth() {
+        let shallow: TopK<Vec<u8>> = TopK::new(10, 100, 2, 0.9);
+        let deep: TopK<Vec<u8>> = TopK::new(10, 100, 8, 0.9);
+        assert!(deep.mem_bytes() > shallow.mem_bytes());
+    }
 
     /// Tests basic initialization of TopK with default parameters
     #[test]

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -40,7 +40,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     /// Computed from allocated *capacity* of the `HashMap`, heap vector,
     /// item store, and free-slot list. Excludes heap owned by individual
     /// `T` values, and the `HashMap` term is an approximation.
-    pub(crate) fn heap_size_bytes(&self) -> usize {
+    pub(crate) fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
         // hashbrown stores each entry as (K, V) plus one control byte.
         let map_entry = size_of::<(T, (u64, usize))>() + 1;

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -35,6 +35,21 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len()
     }
 
+    /// Returns an estimate of heap memory (in bytes) used by this queue.
+    ///
+    /// Computed from allocated *capacity* of the `HashMap`, heap vector,
+    /// item store, and free-slot list. Excludes heap owned by individual
+    /// `T` values, and the `HashMap` term is an approximation.
+    pub(crate) fn heap_size_bytes(&self) -> usize {
+        use std::mem::size_of;
+        // hashbrown stores each entry as (K, V) plus one control byte.
+        let map_entry = size_of::<(T, (u64, usize))>() + 1;
+        self.items.capacity() * map_entry
+            + self.heap.capacity() * size_of::<(u64, usize, usize)>()
+            + self.item_store.capacity() * size_of::<T>()
+            + self.free_slots.capacity() * size_of::<usize>()
+    }
+
     pub(crate) fn get<Q>(&self, item: &Q) -> Option<u64>
     where
         T: Borrow<Q>,


### PR DESCRIPTION
## Summary

Addressing #75 

Adds a public `mem_bytes()` method, returning an estimate of the heap memory each sketch instance holds. This gives users per-object memory visibility for capacity planning across sketches built with different configurations.

| Sketch | Counted |
|---|---|
| `TopK` | outer bucket `Vec` + per-row `Bucket` allocations + decay table + priority queue |
| `BucketedTopK` | cell array + decay table + priority queue |
| `CuckooTopK` | lobby cells + heavy cells + decay table + priority queue |

Priority-queue accounting lives in a shared, crate-private `TopKQueue::heap_size_bytes()` helper that sizes the `HashMap`, heap vector, item store, and free-slot list by their allocated capacity, so all three sketches stay consistent.

## Notes
- Excludes heap owned by individual tracked `T` values (e.g. the contents of a `String`/`Vec` key, which live behind a pointer).
- The `HashMap` term is an approximation — exact per-entry overhead is an implementation detail of the map .

## Tests

Tests to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mem_bytes()` memory-footprint estimators to multiple Top-K data structures, helping you monitor and compare heap usage as configuration parameters change.

* **Tests**
  * Extended the test suite with new `mem_bytes()` validations to confirm correct accounting for fixed sketch allocations and that estimates grow with wider or deeper configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->