### PR TITLE
fix: account for HashMap backing allocation and per-item heap in mem_bytes()

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -323,26 +323,18 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         nodes
     }
 
-    /// Estimated heap memory (in bytes) used by this sketch.
-    pub fn mem_bytes(&self) -> usize {
-        use std::mem::size_of;
-        self.cells.len() * size_of::<Cell>()
-            + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.mem_bytes()
-    }
-
-    /// Like [`mem_bytes`](Self::mem_bytes), plus the heap each tracked item
-    /// owns beyond `size_of::<T>()`. `item_heap(t)` returns the bytes `t`
-    /// points to (e.g. `Vec`/`String::capacity`); pass `|_| 0` for a `T` that
-    /// owns no heap.
-    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    /// Estimated heap memory (in bytes) used by this sketch, including the heap
+    /// each tracked item owns beyond `size_of::<T>()`. `item_heap(t)` returns
+    /// the bytes `t` points to (e.g. `Vec`/`String::capacity`); pass `|_| 0`
+    /// for a `T` that owns no heap.
+    pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where
         F: Fn(&T) -> usize,
     {
         use std::mem::size_of;
         self.cells.len() * size_of::<Cell>()
             + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.mem_bytes_with(item_heap)
+            + self.priority_queue.mem_bytes(item_heap)
     }
 
     /// Merge `other` into `self`. PQ merged first using pre-merge bucket
@@ -611,21 +603,21 @@ mod tests {
         let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
         // The fixed cell array and decay table are exact; the priority
         // queue adds more on top.
-        assert!(topk.mem_bytes() >= cells + decay);
+        assert!(topk.mem_bytes(|_| 0) >= cells + decay);
     }
 
     #[test]
     fn test_mem_bytes_grows_with_width() {
         let small: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 4, 0.9);
         let large: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 400, 4, 0.9);
-        assert!(large.mem_bytes() > small.mem_bytes());
+        assert!(large.mem_bytes(|_| 0) > small.mem_bytes(|_| 0));
     }
 
     #[test]
     fn test_mem_bytes_grows_with_depth() {
         let shallow: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 2, 0.9);
         let deep: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 100, 8, 0.9);
-        assert!(deep.mem_bytes() > shallow.mem_bytes());
+        assert!(deep.mem_bytes(|_| 0) > shallow.mem_bytes(|_| 0));
     }
 
     #[test]

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -331,6 +331,20 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
             + self.priority_queue.mem_bytes()
     }
 
+    /// Like [`mem_bytes`](Self::mem_bytes), plus the heap each tracked item
+    /// owns beyond `size_of::<T>()`. `item_heap(t)` returns the bytes `t`
+    /// points to (e.g. `Vec`/`String::capacity`); pass `|_| 0` for a `T` that
+    /// owns no heap.
+    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    where
+        F: Fn(&T) -> usize,
+    {
+        use std::mem::size_of;
+        self.cells.len() * size_of::<Cell>()
+            + self.decay_thresholds.len() * size_of::<u64>()
+            + self.priority_queue.mem_bytes_with(item_heap)
+    }
+
     /// Merge `other` into `self`. PQ merged first using pre-merge bucket
     /// counts as fallback; cells then unioned per bucket by fingerprint
     /// (min-count eviction on full buckets).

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -325,7 +325,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
 
     /// Estimated heap memory (in bytes) used by this sketch, including the heap
     /// each tracked item owns beyond `size_of::<T>()`. `item_heap(t)` returns
-    /// the bytes `t` points to (e.g. `Vec`/`String::capacity`); pass `|_| 0`
+    /// the bytes `t` points to (e.g. `String::capacity`); pass `|_| 0`
     /// for a `T` that owns no heap.
     pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -382,23 +382,11 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     /// Estimated heap memory (in bytes) used by this sketch.
     ///
     /// Sums the lobby and heavy cell arrays, the precomputed decay-threshold
-    /// table, and the priority queue's allocations. Excludes heap owned by
-    /// individual tracked `T` values; see [`mem_bytes_with`] to include it.
-    ///
-    /// [`mem_bytes_with`]: Self::mem_bytes_with
-    pub fn mem_bytes(&self) -> usize {
-        use std::mem::size_of;
-        self.lobbies.len() * size_of::<Cell>()
-            + self.heavy.len() * size_of::<Cell>()
-            + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.mem_bytes()
-    }
-
-    /// Like [`mem_bytes`], but also counts the heap each tracked item owns
-    /// beyond its inline `size_of::<T>()`. `item_heap(t)` should return the
-    /// bytes `t` points to (e.g. `Vec::capacity`/`String::capacity`); for a
-    /// `T` that owns no heap, pass `|_| 0` to recover [`mem_bytes`].
-    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    /// table, and the priority queue's allocations, plus the heap each tracked
+    /// item owns beyond its inline `size_of::<T>()`. `item_heap(t)` should
+    /// return the bytes `t` points to (e.g. `Vec::capacity`/`String::capacity`);
+    /// for a `T` that owns no heap, pass `|_| 0`.
+    pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where
         F: Fn(&T) -> usize,
     {
@@ -406,7 +394,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         self.lobbies.len() * size_of::<Cell>()
             + self.heavy.len() * size_of::<Cell>()
             + self.decay_thresholds.len() * size_of::<u64>()
-            + self.priority_queue.mem_bytes_with(item_heap)
+            + self.priority_queue.mem_bytes(item_heap)
     }
 
     /// Merge `other` into `self`. Both sketches must share width, depth,
@@ -921,21 +909,21 @@ mod tests {
         let heavy = 64 * 3 * cell;
         let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
         // The fixed sketch arrays are exact; the priority queue adds more.
-        assert!(topk.mem_bytes() >= lobbies + heavy + decay);
+        assert!(topk.mem_bytes(|_| 0) >= lobbies + heavy + decay);
     }
 
     #[test]
     fn test_mem_bytes_grows_with_width() {
         let small: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 3, 0.9);
         let large: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 256, 3, 0.9);
-        assert!(large.mem_bytes() > small.mem_bytes());
+        assert!(large.mem_bytes(|_| 0) > small.mem_bytes(|_| 0));
     }
 
     #[test]
     fn test_mem_bytes_grows_with_depth() {
         let shallow: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 2, 0.9);
         let deep: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 8, 0.9);
-        assert!(deep.mem_bytes() > shallow.mem_bytes());
+        assert!(deep.mem_bytes(|_| 0) > shallow.mem_bytes(|_| 0));
     }
 
     #[test]

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -384,8 +384,8 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     /// Sums the lobby and heavy cell arrays, the precomputed decay-threshold
     /// table, and the priority queue's allocations, plus the heap each tracked
     /// item owns beyond its inline `size_of::<T>()`. `item_heap(t)` should
-    /// return the bytes `t` points to (e.g. `Vec::capacity`/`String::capacity`);
-    /// for a `T` that owns no heap, pass `|_| 0`.
+    /// return the bytes `t` points to (e.g. `String::capacity`); for a `T`
+    /// that owns no heap, pass `|_| 0`.
     pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where
         F: Fn(&T) -> usize,

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -382,8 +382,10 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     /// Estimated heap memory (in bytes) used by this sketch.
     ///
     /// Sums the lobby and heavy cell arrays, the precomputed decay-threshold
-    /// table, and the priority queue's allocations. This is an approximation:
-    /// it excludes heap owned by individual tracked `T` values.                                                                       
+    /// table, and the priority queue's allocations. Excludes heap owned by
+    /// individual tracked `T` values; see [`mem_bytes_with`] to include it.
+    ///
+    /// [`mem_bytes_with`]: Self::mem_bytes_with
     pub fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
         self.lobbies.len() * size_of::<Cell>()

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -383,13 +383,28 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     ///
     /// Sums the lobby and heavy cell arrays, the precomputed decay-threshold
     /// table, and the priority queue's allocations. This is an approximation:
-    /// it excludes heap owned by individual tracked `T` values                                                                        
+    /// it excludes heap owned by individual tracked `T` values.                                                                       
     pub fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
         self.lobbies.len() * size_of::<Cell>()
             + self.heavy.len() * size_of::<Cell>()
             + self.decay_thresholds.len() * size_of::<u64>()
             + self.priority_queue.mem_bytes()
+    }
+
+    /// Like [`mem_bytes`], but also counts the heap each tracked item owns
+    /// beyond its inline `size_of::<T>()`. `item_heap(t)` should return the
+    /// bytes `t` points to (e.g. `Vec::capacity`/`String::capacity`); for a
+    /// `T` that owns no heap, pass `|_| 0` to recover [`mem_bytes`].
+    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    where
+        F: Fn(&T) -> usize,
+    {
+        use std::mem::size_of;
+        self.lobbies.len() * size_of::<Cell>()
+            + self.heavy.len() * size_of::<Cell>()
+            + self.decay_thresholds.len() * size_of::<u64>()
+            + self.priority_queue.mem_bytes_with(item_heap)
     }
 
     /// Merge `other` into `self`. Both sketches must share width, depth,

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -375,7 +375,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
 
     /// Estimated heap memory (in bytes) used by this sketch, including the heap
     /// each tracked item owns beyond `size_of::<T>()`. `item_heap(t)` returns
-    /// the bytes `t` points to (e.g. `Vec`/`String::capacity`); pass `|_| 0`
+    /// the bytes `t` points to (e.g. `String::capacity`); pass `|_| 0`
     /// for a `T` that owns no heap.
     pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -373,26 +373,11 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         nodes
     }
 
-    /// Estimated heap memory (in bytes) used by this sketch.
-    pub fn mem_bytes(&self) -> usize {
-        use std::mem::size_of;
-        let outer = self.buckets.capacity() * size_of::<Vec<Bucket>>();
-        let rows: usize = self
-            .buckets
-            .iter()
-            .map(|row| row.capacity() * size_of::<Bucket>())
-            .sum();
-        outer
-            + rows
-            + self.decay_thresholds.capacity() * size_of::<u64>()
-            + self.priority_queue.mem_bytes()
-    }
-
-    /// Like [`mem_bytes`](Self::mem_bytes), plus the heap each tracked item
-    /// owns beyond `size_of::<T>()`. `item_heap(t)` returns the bytes `t`
-    /// points to (e.g. `Vec`/`String::capacity`); pass `|_| 0` for a `T` that
-    /// owns no heap.
-    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    /// Estimated heap memory (in bytes) used by this sketch, including the heap
+    /// each tracked item owns beyond `size_of::<T>()`. `item_heap(t)` returns
+    /// the bytes `t` points to (e.g. `Vec`/`String::capacity`); pass `|_| 0`
+    /// for a `T` that owns no heap.
+    pub fn mem_bytes<F>(&self, item_heap: F) -> usize
     where
         F: Fn(&T) -> usize,
     {
@@ -406,7 +391,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         outer
             + rows
             + self.decay_thresholds.capacity() * size_of::<u64>()
-            + self.priority_queue.mem_bytes_with(item_heap)
+            + self.priority_queue.mem_bytes(item_heap)
     }
 
     // Merge another HeavyKeeper into this one
@@ -595,21 +580,21 @@ mod tests {
         let decay = DECAY_LOOKUP_SIZE * std::mem::size_of::<u64>();
         // The per-row Bucket allocations and decay table are accounted for;
         // the outer Vec and priority queue add more on top.
-        assert!(topk.mem_bytes() >= rows + decay);
+        assert!(topk.mem_bytes(|_| 0) >= rows + decay);
     }
 
     #[test]
     fn test_mem_bytes_grows_with_width() {
         let small: TopK<Vec<u8>> = TopK::new(10, 100, 5, 0.9);
         let large: TopK<Vec<u8>> = TopK::new(10, 400, 5, 0.9);
-        assert!(large.mem_bytes() > small.mem_bytes());
+        assert!(large.mem_bytes(|_| 0) > small.mem_bytes(|_| 0));
     }
 
     #[test]
     fn test_mem_bytes_grows_with_depth() {
         let shallow: TopK<Vec<u8>> = TopK::new(10, 100, 2, 0.9);
         let deep: TopK<Vec<u8>> = TopK::new(10, 100, 8, 0.9);
-        assert!(deep.mem_bytes() > shallow.mem_bytes());
+        assert!(deep.mem_bytes(|_| 0) > shallow.mem_bytes(|_| 0));
     }
 
     /// Tests basic initialization of TopK with default parameters

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -388,6 +388,27 @@ impl<T: Ord + Clone + Hash> TopK<T> {
             + self.priority_queue.mem_bytes()
     }
 
+    /// Like [`mem_bytes`](Self::mem_bytes), plus the heap each tracked item
+    /// owns beyond `size_of::<T>()`. `item_heap(t)` returns the bytes `t`
+    /// points to (e.g. `Vec`/`String::capacity`); pass `|_| 0` for a `T` that
+    /// owns no heap.
+    pub fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    where
+        F: Fn(&T) -> usize,
+    {
+        use std::mem::size_of;
+        let outer = self.buckets.capacity() * size_of::<Vec<Bucket>>();
+        let rows: usize = self
+            .buckets
+            .iter()
+            .map(|row| row.capacity() * size_of::<Bucket>())
+            .sum();
+        outer
+            + rows
+            + self.decay_thresholds.capacity() * size_of::<u64>()
+            + self.priority_queue.mem_bytes_with(item_heap)
+    }
+
     // Merge another HeavyKeeper into this one
     pub fn merge(&mut self, other: &Self) -> Result<(), HeavyKeeperError> {
         // Verify compatible parameters

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -75,7 +75,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         F: Fn(&T) -> usize,
     {
         // `items` is the source of truth for which items are live.
-        let item_bytes: usize = self.items.keys().map(|t| item_heap(t)).sum();
+        let item_bytes: usize = self.items.keys().map(item_heap).sum();
         self.mem_bytes() + 2 * item_bytes
     }
 

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -42,12 +42,26 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     /// `T` values, and the `HashMap` term is an approximation.
     pub(crate) fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
-        // hashbrown stores each entry as (K, V) plus one control byte.
         let map_entry = size_of::<(T, (u64, usize))>() + 1;
         self.items.capacity() * map_entry
             + self.heap.capacity() * size_of::<(u64, usize, usize)>()
             + self.item_store.capacity() * size_of::<T>()
             + self.free_slots.capacity() * size_of::<usize>()
+    }
+
+    /// Like [`mem_bytes`], plus the heap each live item owns beyond its inline
+    /// `size_of::<T>()`. `item_heap(t)` should return the bytes `t` points to
+    /// (e.g. `Vec::capacity`/`String::capacity`)
+    ///
+    /// Each tracked item is stored twice — once as a `HashMap` key and once in
+    /// `item_store` — so its owned heap is counted twice to match.
+    pub(crate) fn mem_bytes_with<F>(&self, item_heap: F) -> usize
+    where
+        F: Fn(&T) -> usize,
+    {
+        // `items` is the source of truth for which items are live.
+        let item_bytes: usize = self.items.keys().map(|t| item_heap(t)).sum();
+        self.mem_bytes() + 2 * item_bytes
     }
 
     pub(crate) fn get<Q>(&self, item: &Q) -> Option<u64>

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -45,12 +45,12 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     /// public API, but stable in practice across std releases).
     pub(crate) fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
-        // hashbrown internals: `buckets` is the next power of two >= capacity*8/7.
+        // hashbrown internals: `buckets` is the next power of two >= ceil(capacity*8/7).
         let cap = self.items.capacity();
         let buckets = if cap == 0 {
             0
         } else {
-            (cap * 8 / 7).next_power_of_two()
+            ((cap * 8 + 6) / 7).next_power_of_two()
         };
         const GROUP_WIDTH: usize = 16;
         let map_bytes = if buckets == 0 {

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -35,15 +35,30 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len()
     }
 
-    /// Returns an estimate of heap memory (in bytes) used by this queue.
+    /// Returns the heap memory (in bytes) used by this queue's containers.
     ///
-    /// Computed from allocated *capacity* of the `HashMap`, heap vector,
-    /// item store, and free-slot list. Excludes heap owned by individual
-    /// `T` values, and the `HashMap` term is an approximation.
+    /// Computed from the allocated *capacity* of the `HashMap`, heap vector,
+    /// item store, and free-slot list. Excludes heap owned by individual `T`
+    /// values (see [`mem_bytes_with`](Self::mem_bytes_with)).
+    ///
+    /// The `HashMap` term mirrors hashbrown's internal SwissTable layout (not
+    /// public API, but stable in practice across std releases).
     pub(crate) fn mem_bytes(&self) -> usize {
         use std::mem::size_of;
-        let map_entry = size_of::<(T, (u64, usize))>() + 1;
-        self.items.capacity() * map_entry
+        // hashbrown internals: `buckets` is the next power of two >= capacity*8/7.
+        let cap = self.items.capacity();
+        let buckets = if cap == 0 {
+            0
+        } else {
+            (cap * 8 / 7).next_power_of_two()
+        };
+        const GROUP_WIDTH: usize = 16;
+        let map_bytes = if buckets == 0 {
+            0
+        } else {
+            buckets * size_of::<(T, (u64, usize))>() + buckets + GROUP_WIDTH
+        };
+        map_bytes
             + self.heap.capacity() * size_of::<(u64, usize, usize)>()
             + self.item_store.capacity() * size_of::<T>()
             + self.free_slots.capacity() * size_of::<usize>()

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -38,12 +38,19 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     /// Returns the heap memory (in bytes) used by this queue's containers.
     ///
     /// Computed from the allocated *capacity* of the `HashMap`, heap vector,
-    /// item store, and free-slot list. Excludes heap owned by individual `T`
-    /// values (see [`mem_bytes_with`](Self::mem_bytes_with)).
+    /// item store, and free-slot list, plus the heap each live item owns beyond
+    /// its inline `size_of::<T>()`. `item_heap(t)` should return the bytes `t`
+    /// points to (e.g. `Vec::capacity`/`String::capacity`).
     ///
     /// The `HashMap` term mirrors hashbrown's internal SwissTable layout (not
     /// public API, but stable in practice across std releases).
-    pub(crate) fn mem_bytes(&self) -> usize {
+    ///
+    /// Each tracked item is stored twice: once as a `HashMap` key and once in
+    /// `item_store`.
+    pub(crate) fn mem_bytes<F>(&self, item_heap: F) -> usize
+    where
+        F: Fn(&T) -> usize,
+    {
         use std::mem::size_of;
         // hashbrown internals: `buckets` is the next power of two >= ceil(capacity*8/7).
         let cap = self.items.capacity();
@@ -58,25 +65,13 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         } else {
             buckets * size_of::<(T, (u64, usize))>() + buckets + GROUP_WIDTH
         };
+        // `items` is the source of truth for which items are live.
+        let item_bytes: usize = self.items.keys().map(item_heap).sum();
         map_bytes
             + self.heap.capacity() * size_of::<(u64, usize, usize)>()
             + self.item_store.capacity() * size_of::<T>()
             + self.free_slots.capacity() * size_of::<usize>()
-    }
-
-    /// Like [`mem_bytes`], plus the heap each live item owns beyond its inline
-    /// `size_of::<T>()`. `item_heap(t)` should return the bytes `t` points to
-    /// (e.g. `Vec::capacity`/`String::capacity`)
-    ///
-    /// Each tracked item is stored twice — once as a `HashMap` key and once in
-    /// `item_store` — so its owned heap is counted twice to match.
-    pub(crate) fn mem_bytes_with<F>(&self, item_heap: F) -> usize
-    where
-        F: Fn(&T) -> usize,
-    {
-        // `items` is the source of truth for which items are live.
-        let item_bytes: usize = self.items.keys().map(item_heap).sum();
-        self.mem_bytes() + 2 * item_bytes
+            + 2 * item_bytes
     }
 
     pub(crate) fn get<Q>(&self, item: &Q) -> Option<u64>

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -40,7 +40,7 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
     /// Computed from the allocated *capacity* of the `HashMap`, heap vector,
     /// item store, and free-slot list, plus the heap each live item owns beyond
     /// its inline `size_of::<T>()`. `item_heap(t)` should return the bytes `t`
-    /// points to (e.g. `Vec::capacity`/`String::capacity`).
+    /// points to (e.g. `String::capacity`).
     ///
     /// The `HashMap` term mirrors hashbrown's internal SwissTable layout (not
     /// public API, but stable in practice across std releases).

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -59,7 +59,16 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         } else {
             ((cap * 8 + 6) / 7).next_power_of_two()
         };
+        #[cfg(all(
+            target_feature = "sse2",
+            any(target_arch = "x86", target_arch = "x86_64")
+        ))]
         const GROUP_WIDTH: usize = 16;
+        #[cfg(not(all(
+            target_feature = "sse2",
+            any(target_arch = "x86", target_arch = "x86_64")
+        )))]
+        const GROUP_WIDTH: usize = 8;
         let map_bytes = if buckets == 0 {
             0
         } else {


### PR DESCRIPTION
## Summary

Addressing https://github.com/pmcgleenon/heavykeeper-rs/issues/75 and follow-up to the `mem_bytes()` work https://github.com/pmcgleenon/heavykeeper-rs/pull/85.
The estimate now accounts for all heap bytes each sketch holds, including item buffers and HashMap backing allocation.

Two changes:

1. **Accurate `HashMap` allocation.** The previous `mem_bytes()` approximated the map as `capacity * (entry + 1 control byte)`. It now mirrors hashbrown's actual SwissTable layout:`buckets = next_pow2(ceil(capacity * 8 / 7))`, then `buckets * size_of::<(K,V)>() + buckets + GROUP_WIDTH` .

2. **Counts heap owned by tracked items.** `mem_bytes` now takes an `item_heap: Fn(&T) -> usize` closure returning the bytes each item points to (e.g. `String`/`Vec` contents). Items are stored twice (HashMap key + `item_store`), so the per-item heap is counted twice to match.

| Sketch | Counted |
|---|---|
| `TopK` | outer bucket `Vec` + per-row `Bucket` allocations + decay table + priority queue + tracked-item heap |
| `BucketedTopK` | cell array + decay table + priority queue + tracked-item heap |
| `CuckooTopK` | lobby cells + heavy cells + decay table + priority queue + tracked-item heap |

Priority-queue accounting stays in the shared crate-private `TopKQueue::mem_bytes()` helper so all three sketches remain consistent.

## Notes

- `mem_bytes()` no longer takes zero arguments — it now requires an `item_heap` closure. The earlier `mem_bytes()` / `mem_bytes_with()` split is folded into a single `mem_bytes(item_heap)`. Migrate:

  ```rust
  sketch.mem_bytes()                  // before
  sketch.mem_bytes(|_| 0)             // after — no per-item heap
  sketch.mem_bytes(|s| s.capacity())  // after — e.g. String items
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory usage estimates now account for per-item heap allocations, making reported sizes more accurate.
  * Updated memory estimation APIs to accept a callback for item-specific heap usage.

* **Bug Fixes**
  * Improved memory reporting for top-k data structures so growth estimates better reflect real-world usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->