### PR TITLE
feat: return (evicted, inserted) from add_with_evicted

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -184,13 +184,13 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         let _ = self.add_with_evicted(item, increment);
     }
 
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> (Option<T>, bool)
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
         if increment == 0 {
-            return None;
+            return (None, false);
         }
         let h = self.hasher.hash_one(item);
         let fp = h;
@@ -220,7 +220,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
             }
         }
 
-        let inserted: Option<u64> = if let Some(i) = matched {
+        let cell_count: Option<u64> = if let Some(i) = matched {
             cells[i].count = cells[i].count.saturating_add(increment);
             Some(cells[i].count)
         } else if let Some(i) = first_empty {
@@ -231,7 +231,10 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
             self.decay_and_maybe_evict(bucket_start, min_idx, fp, increment)
         };
 
-        let max_count = inserted?;
+        let max_count = match cell_count {
+            Some(c) => c,
+            None => return (None, false),
+        };
 
         // Paper Algorithm 1: heap value is max(maxv, existing_heap_value).
         // Item already in PQ → only raise; cell-decay must not drag PQ down.
@@ -240,16 +243,18 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
                 self.priority_queue.update_if_present(item, max_count);
                 self.min_pq_count = self.priority_queue.min_count();
             }
-            return None;
+            return (None, false);
         }
 
         if self.priority_queue.is_full() && max_count <= self.min_pq_count {
-            return None;
+            return (None, false);
         }
 
+        let had_room = !self.priority_queue.is_full();
         let evicted = self.priority_queue.upsert(item.to_owned(), max_count);
         self.min_pq_count = self.priority_queue.min_count();
-        evicted
+        let inserted = evicted.is_some() || had_room;
+        (evicted, inserted)
     }
 
     pub fn count<Q>(&self, item: &Q) -> u64
@@ -1128,14 +1133,14 @@ mod tests {
     fn test_add_with_evicted_returns_displaced_item() {
         let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
 
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
-        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        // New keys into free space: no eviction, but inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 5), (None, true));
+        assert_eq!(topk.add_with_evicted(&b"b".to_vec(), 10), (None, true));
         assert_eq!(topk.list().len(), 2);
 
-        let evicted = topk
-            .add_with_evicted(&b"c".to_vec(), 20)
-            .expect("expected an eviction");
-        assert_eq!(evicted, b"a".to_vec());
+        let (evicted, inserted) = topk.add_with_evicted(&b"c".to_vec(), 20);
+        assert_eq!(evicted.expect("expected an eviction"), b"a".to_vec());
+        assert!(inserted);
 
         let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
         assert!(items.contains(&b"b".to_vec()));
@@ -1147,20 +1152,20 @@ mod tests {
     fn test_add_with_evicted_no_eviction_cases() {
         let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
 
-        // increment == 0 → no work, no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+        // increment == 0 → no work, nothing tracked.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 0), (None, false));
 
-        // PQ not yet full → no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
-        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        // PQ not yet full → no eviction, but inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 5), (None, true));
+        assert_eq!(topk.add_with_evicted(&b"b".to_vec(), 10), (None, true));
 
-        // Updating an already-tracked item → no eviction even at capacity.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+        // Updating an already-tracked item → neither evicted nor inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 1), (None, false));
 
-        // New item whose count cannot beat the PQ minimum → no eviction.
+        // New item whose count cannot beat the PQ minimum → nothing tracked.
         let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(2, 64, 4, 0.9);
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
-        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
+        assert_eq!(topk.add_with_evicted(&b"cold".to_vec(), 10), (None, false));
     }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -236,21 +236,20 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         let _ = self.add_with_evicted(item, increment);
     }
 
-    /// Same as [`add`], but returns the top-k item that was displaced from
-    /// the priority queue by this call, if any. An eviction happens only
-    /// when the priority queue is at capacity and `item` reaches a count
-    /// strictly greater than the current minimum tracked count. Returns
-    /// `None` when nothing was evicted (queue not yet full, item already
-    /// tracked, or count too low to displace the current min).
+    /// Same as [`add`], but returns `(evicted, inserted)`: `evicted` is the
+    /// top-k item displaced from a full priority queue by this call (if any),
+    /// and `inserted` is `true` when `item` became newly tracked (into free
+    /// space, or by displacing `evicted`). Updating an already-tracked item,
+    /// or a count too low to be tracked, yields `(None, false)`.
     ///
     /// [`add`]: CuckooTopK::add
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> (Option<T>, bool)
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
         if increment == 0 {
-            return None;
+            return (None, false);
         }
 
         let fp = self.hasher.hash_one(item);
@@ -261,13 +260,16 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
             return self.update_priority_queue(item, self.heavy[idx].count);
         }
 
-        let lobby_count = self.update_lobby(primary, fp, increment)?;
+        let lobby_count = match self.update_lobby(primary, fp, increment) {
+            Some(c) => c,
+            None => return (None, false),
+        };
 
         if self.promote(fp, lobby_count, primary, alternate) {
             self.clear_lobby(primary, fp);
             return self.update_priority_queue(item, lobby_count);
         }
-        None
+        (None, false)
     }
 
     /// Estimated count for `item`. Consults the priority queue first
@@ -740,7 +742,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
     }
 
-    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64) -> Option<T>
+    fn update_priority_queue<Q>(&mut self, item: &Q, count: u64) -> (Option<T>, bool)
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
@@ -750,16 +752,18 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
                 self.priority_queue.update_if_present(item, count);
                 self.min_pq_count = self.priority_queue.min_count();
             }
-            return None;
+            return (None, false);
         }
 
         if self.priority_queue.is_full() && count <= self.min_pq_count {
-            return None;
+            return (None, false);
         }
 
+        let had_room = !self.priority_queue.is_full();
         let evicted = self.priority_queue.upsert(item.to_owned(), count);
         self.min_pq_count = self.priority_queue.min_count();
-        evicted
+        let inserted = evicted.is_some() || had_room;
+        (evicted, inserted)
     }
 }
 
@@ -1359,20 +1363,24 @@ mod tests {
 
         // Pump enough to force promotion into heavy slots so PQ gets
         // populated.
-        let none1 = topk.add_with_evicted(&b"a".to_vec(), 5);
-        let none2 = topk.add_with_evicted(&b"b".to_vec(), 10);
-        assert!(none1.is_none(), "first add should not evict");
-        assert!(
-            none2.is_none(),
-            "second add (still under k) should not evict"
+        // New keys into free space: no eviction, but inserted.
+        assert_eq!(
+            topk.add_with_evicted(&b"a".to_vec(), 5),
+            (None, true),
+            "first add should insert without evicting"
+        );
+        assert_eq!(
+            topk.add_with_evicted(&b"b".to_vec(), 10),
+            (None, true),
+            "second add (still under k) should insert without evicting"
         );
 
         // Sanity-check both items reached the priority queue.
         let list = topk.list();
         assert_eq!(list.len(), 2);
-        let evicted = topk.add_with_evicted(&b"c".to_vec(), 20);
-        let evicted = evicted.expect("expected an eviction");
-        assert_eq!(evicted, b"a".to_vec());
+        let (evicted, inserted) = topk.add_with_evicted(&b"c".to_vec(), 20);
+        assert_eq!(evicted.expect("expected an eviction"), b"a".to_vec());
+        assert!(inserted);
 
         // PQ now holds b and c.
         let list = topk.list();
@@ -1386,23 +1394,23 @@ mod tests {
     fn test_add_with_evicted_no_eviction_cases() {
         let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 64, 2, 0.9);
 
-        // increment == 0 → no work, no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+        // increment == 0 → no work, nothing tracked.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 0), (None, false));
 
-        // PQ not yet full → no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
-        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        // PQ not yet full → no eviction, but inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 5), (None, true));
+        assert_eq!(topk.add_with_evicted(&b"b".to_vec(), 10), (None, true));
 
-        // Updating an already-tracked item → no eviction even at capacity.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+        // Updating an already-tracked item → neither evicted nor inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 1), (None, false));
 
         // New item with count not high enough to beat the PQ minimum (5)
-        // → no eviction. Use a fresh sketch so heavy slots are free for
+        // → nothing tracked. Use a fresh sketch so heavy slots are free for
         // promotion.
         let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(2, 64, 2, 0.9);
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
-        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
+        assert_eq!(topk.add_with_evicted(&b"cold".to_vec(), 10), (None, false));
     }
 
     #[test]

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -337,6 +337,11 @@ impl<T: Ord + Clone + Hash> TopK<T> {
             return (None, false);
         }
 
+        // All rows rejected the item: no count, so don't track it.
+        if max_count == 0 {
+            return (None, false);
+        }
+
         if self.priority_queue.is_full() && max_count <= self.priority_queue.min_count() {
             return (None, false);
         }

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -278,13 +278,13 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         let _ = self.add_with_evicted(item, increment);
     }
 
-    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> Option<T>
+    pub fn add_with_evicted<Q>(&mut self, item: &Q, increment: u64) -> (Option<T>, bool)
     where
         T: Borrow<Q>,
         Q: Hash + Eq + ToOwned<Owned = T> + ?Sized,
     {
         if increment == 0 {
-            return None;
+            return (None, false);
         }
         let mut composer = HashComposer::new(&self.hasher, item);
         let mut max_count: u64 = 0;
@@ -334,15 +334,18 @@ impl<T: Ord + Clone + Hash> TopK<T> {
             if max_count > current {
                 self.priority_queue.update_if_present(item, max_count);
             }
-            return None;
+            return (None, false);
         }
 
         if self.priority_queue.is_full() && max_count <= self.priority_queue.min_count() {
-            return None;
+            return (None, false);
         }
 
+        let had_room = !self.priority_queue.is_full();
         // Clone the item here since we need to store it in the priority queue
-        self.priority_queue.upsert(item.to_owned(), max_count)
+        let evicted = self.priority_queue.upsert(item.to_owned(), max_count);
+        let inserted = evicted.is_some() || had_room;
+        (evicted, inserted)
     }
 
     fn decay_threshold(&self, count: u64) -> u64 {
@@ -1511,14 +1514,14 @@ mod tests {
     fn test_add_with_evicted_returns_displaced_item() {
         let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
 
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
-        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        // New keys into free space: no eviction, but inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 5), (None, true));
+        assert_eq!(topk.add_with_evicted(&b"b".to_vec(), 10), (None, true));
         assert_eq!(topk.list().len(), 2);
 
-        let evicted = topk
-            .add_with_evicted(&b"c".to_vec(), 20)
-            .expect("expected an eviction");
-        assert_eq!(evicted, b"a".to_vec());
+        let (evicted, inserted) = topk.add_with_evicted(&b"c".to_vec(), 20);
+        assert_eq!(evicted.expect("expected an eviction"), b"a".to_vec());
+        assert!(inserted);
 
         let items: Vec<_> = topk.list().iter().map(|n| n.item.clone()).collect();
         assert!(items.contains(&b"b".to_vec()));
@@ -1530,20 +1533,20 @@ mod tests {
     fn test_add_with_evicted_no_eviction_cases() {
         let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
 
-        // increment == 0 → no work, no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 0).is_none());
+        // increment == 0 → no work, nothing tracked.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 0), (None, false));
 
-        // PQ not yet full → no eviction.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 5).is_none());
-        assert!(topk.add_with_evicted(&b"b".to_vec(), 10).is_none());
+        // PQ not yet full → no eviction, but inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 5), (None, true));
+        assert_eq!(topk.add_with_evicted(&b"b".to_vec(), 10), (None, true));
 
-        // Updating an already-tracked item → no eviction even at capacity.
-        assert!(topk.add_with_evicted(&b"a".to_vec(), 1).is_none());
+        // Updating an already-tracked item → neither evicted nor inserted.
+        assert_eq!(topk.add_with_evicted(&b"a".to_vec(), 1), (None, false));
 
-        // New item whose count cannot beat the PQ minimum → no eviction.
+        // New item whose count cannot beat the PQ minimum → nothing tracked.
         let mut topk: TopK<Vec<u8>> = TopK::new(2, 100, 5, 0.9);
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
-        assert!(topk.add_with_evicted(&b"cold".to_vec(), 10).is_none());
+        assert_eq!(topk.add_with_evicted(&b"cold".to_vec(), 10), (None, false));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #77. That PR made `add_with_evicted` return the item displaced from a full priority queue. But a `None` return was ambiguous: it covered both "item got tracked into the top-k, just didn't evict anyone" and "item never made it into the top-k at all."

This changes the return type from `Option<T>` to `(Option<T>, bool)`, where the new `bool` (`inserted`) tells you whether `item` actually entered the tracked top-k set. The new signal is entirely in the no-eviction case:

| Return | Meaning |
|---|---|
| `(None, true)` | `item` **was tracked** (entered free space in a non-full PQ), no eviction |
| `(None, false)` | `item` was **not tracked** — already-tracked update, count too low to qualify, or `increment == 0` |
| `(Some(x), true)` | `item` was tracked by displacing `x` from a full PQ |

`inserted` is computed as `evicted.is_some() || had_room`, where `had_room` is captured before the `upsert`.

Applies consistently across all three sketches (`TopK`, `BucketedTopK`, `CuckooTopK`); the shared logic in `CuckooTopK::update_priority_queue` returns the tuple too.

## Notes
- Breaking change to `add_with_evicted`'s signature. The `add` wrapper is unaffected .
- Migration: `let evicted = sketch.add_with_evicted(..)` → `let (evicted, inserted) = sketch.add_with_evicted(..)`.

## Tests

Updated `test_add_with_evicted_returns_displaced_item` and `test_add_with_evicted_no_eviction_cases` in all three sketches to assert the full `(evicted, inserted)` tuple, covering free-space insertion, eviction, already-tracked updates, sub-threshold counts, and `increment == 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated top-k insertion behavior to clearly report whether an item was tracked, alongside any evicted item.
  * Improved handling of no-op cases such as zero increments, already-tracked items, and items that do not qualify for insertion.
  * Refined results for full-capacity scenarios so successful inserts and skipped inserts are distinguishable.
  
* **Tests**
  * Expanded test coverage to verify the new return values across insertion, eviction, and no-op cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->