### PR TITLE
feat :replace the decay while loop with an O(1) sample binomial sampling 

### DIFF
--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -8,9 +8,10 @@ use std::hash::Hash;
 
 use ahash::RandomState;
 use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+use rand::SeedableRng;
 use thiserror::Error;
 
+use crate::geometric::sample_geometric;
 use crate::priority_queue::TopKQueue;
 
 const DECAY_LOOKUP_SIZE: usize = 1024;
@@ -457,22 +458,37 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         increment: u64,
     ) -> Option<u64> {
         let cell_idx = bucket_start + min_idx;
+        // Per-unit decay, skipping straight to each successful decay with a
+        // geometric sample: distribution-identical to one RNG draw per unit
+        // of increment, but O(decays) so huge increments can't hang.
         let mut remaining = increment;
-        while remaining > 0 {
+        loop {
             let current_count = self.cells[cell_idx].count;
             let threshold = self.decay_threshold(current_count);
-            if self.rng.next_u64() < threshold {
-                let cell = &mut self.cells[cell_idx];
-                cell.count = cell.count.saturating_sub(1);
-                if cell.count == 0 {
-                    cell.fingerprint = fp;
-                    cell.count = remaining;
-                    return Some(remaining);
-                }
+            if threshold == 0 {
+                return None;
             }
-            remaining -= 1;
+            let trials = sample_geometric(threshold, &mut self.rng);
+            if trials > remaining {
+                // The next decay lands beyond this add's budget.
+                return None;
+            }
+            let cell = &mut self.cells[cell_idx];
+            if cell.count <= 1 {
+                // Killing decay: the old loop returned before spending a
+                // unit on the successful trial, so only the trials-1
+                // failures before it consume budget.
+                let new_count = remaining - (trials - 1);
+                cell.fingerprint = fp;
+                cell.count = new_count;
+                return Some(new_count);
+            }
+            cell.count -= 1;
+            remaining -= trials;
+            if remaining == 0 {
+                return None;
+            }
         }
-        None
     }
 
     fn decay_threshold(&self, count: u64) -> u64 {

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -13,9 +13,10 @@ use std::hash::Hash;
 
 use ahash::RandomState;
 use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+use rand::SeedableRng;
 use thiserror::Error;
 
+use crate::geometric::sample_geometric;
 use crate::priority_queue::TopKQueue;
 
 const DECAY_LOOKUP_SIZE: usize = 1024;
@@ -712,22 +713,37 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         fingerprint: u64,
         increment: u64,
     ) -> Option<u64> {
+        // Per-unit decay, skipping straight to each successful decay with a
+        // geometric sample: distribution-identical to one RNG draw per unit
+        // of increment, but O(decays) so huge increments can't hang.
         let mut remaining = increment;
-        while remaining > 0 {
+        loop {
             let current_count = self.lobbies[bucket].count;
             let threshold = self.decay_threshold(current_count);
-            if self.rng.next_u64() < threshold {
-                let lobby = &mut self.lobbies[bucket];
-                lobby.count = lobby.count.saturating_sub(1);
-                if lobby.count == 0 {
-                    lobby.fingerprint = fingerprint;
-                    lobby.count = remaining;
-                    return Some(remaining);
-                }
+            if threshold == 0 {
+                return None;
             }
-            remaining -= 1;
+            let trials = sample_geometric(threshold, &mut self.rng);
+            if trials > remaining {
+                // The next decay lands beyond this add's budget.
+                return None;
+            }
+            let lobby = &mut self.lobbies[bucket];
+            if lobby.count <= 1 {
+                // Killing decay: the old loop returned before spending a
+                // unit on the successful trial, so only the trials-1
+                // failures before it consume budget.
+                let new_count = remaining - (trials - 1);
+                lobby.fingerprint = fingerprint;
+                lobby.count = new_count;
+                return Some(new_count);
+            }
+            lobby.count -= 1;
+            remaining -= trials;
+            if remaining == 0 {
+                return None;
+            }
         }
-        None
     }
 
     fn decay_threshold(&self, count: u64) -> u64 {

--- a/src/geometric.rs
+++ b/src/geometric.rs
@@ -1,0 +1,96 @@
+use rand::Rng;
+
+/// Sample the trial index of the first success in a sequence of Bernoulli
+/// trials that each succeed when `rng.next_u64() < threshold` (success
+/// probability `threshold / 2^64`), without simulating the trials.
+///
+/// Uses inversion: `G = ceil(ln(U) / ln(1 - p))` with `U` uniform in
+/// `(0, 1]`, so `G` is geometric on `{1, 2, ...}`. This lets the decay
+/// loop skip straight to the next successful decay in O(1) instead of
+/// spending one RNG draw per unit of increment.
+///
+/// Returns `u64::MAX` when the first success lies beyond any practical
+/// budget (the inversion overflows for tiny `p`); callers treat a result
+/// larger than their remaining budget as "no decay in this add".
+/// `threshold == 0` (never succeeds) must be short-circuited by the caller.
+pub(crate) fn sample_geometric(threshold: u64, rng: &mut impl Rng) -> u64 {
+    let p = threshold as f64 / (u64::MAX as f64);
+    if p >= 1.0 {
+        return 1;
+    }
+    // 1 - [0, 1) = (0, 1]: avoids ln(0).
+    let u = 1.0 - rng.random::<f64>();
+    // ln(1 - p) via ln_1p keeps precision when p is tiny.
+    let g = (u.ln() / (-p).ln_1p()).ceil();
+    if g < 1.0 {
+        1
+    } else if g >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        g as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn certain_success_takes_one_trial() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        for _ in 0..100 {
+            assert_eq!(sample_geometric(u64::MAX, &mut rng), 1);
+        }
+    }
+
+    #[test]
+    fn tiny_threshold_saturates() {
+        // p ~= 5.4e-20: the first success is astronomically far away and
+        // must not wrap or panic.
+        let mut rng = SmallRng::seed_from_u64(42);
+        for _ in 0..100 {
+            assert!(sample_geometric(1, &mut rng) > 1_000_000_000_000);
+        }
+    }
+
+    #[test]
+    fn mean_matches_one_over_p() {
+        // p = 0.25 -> E[G] = 4. With 100k samples the sample mean has
+        // SEM ~= sqrt(12)/sqrt(100k) ~= 0.011, so +/-0.15 is generous.
+        let threshold = u64::MAX / 4;
+        let mut rng = SmallRng::seed_from_u64(42);
+        let trials = 100_000u64;
+        let sum: u64 = (0..trials)
+            .map(|_| sample_geometric(threshold, &mut rng))
+            .sum();
+        let mean = sum as f64 / trials as f64;
+        assert!(
+            (mean - 4.0).abs() < 0.15,
+            "sample_geometric(p=0.25) mean = {mean}, expected ~4.0"
+        );
+    }
+
+    #[test]
+    fn matches_per_trial_simulation() {
+        // The whole point: G must be distributed like the index of the
+        // first success in per-trial simulation. Compare survival at a
+        // few points against the exact CDF for p = 0.1.
+        let threshold = u64::MAX / 10;
+        let mut rng = SmallRng::seed_from_u64(7);
+        let trials = 100_000u64;
+        let mut le_10 = 0u64;
+        for _ in 0..trials {
+            if sample_geometric(threshold, &mut rng) <= 10 {
+                le_10 += 1;
+            }
+        }
+        // P(G <= 10) = 1 - 0.9^10 ~= 0.6513; SEM ~= 0.0015.
+        let frac = le_10 as f64 / trials as f64;
+        assert!(
+            (frac - 0.6513).abs() < 0.01,
+            "P(G <= 10) = {frac}, expected ~0.6513"
+        );
+    }
+}

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -1,8 +1,9 @@
+use crate::geometric::sample_geometric;
 use crate::hash_composition::HashComposer;
 use crate::priority_queue::TopKQueue;
 use ahash::RandomState;
 use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+use rand::SeedableRng;
 use std::borrow::Borrow;
 use std::clone::Clone;
 use std::fmt::Debug;
@@ -306,24 +307,40 @@ impl<T: Ord + Clone + Hash> TopK<T> {
                 bucket.count += increment;
                 max_count = std::cmp::max(max_count, bucket.count);
             } else {
+                // Per-unit decay, but skipping straight to each successful
+                // decay with a geometric sample instead of one RNG draw per
+                // unit of increment. Distribution-identical to the old
+                // while-loop (probability re-evaluated at every count level,
+                // takeover count = unconsumed remainder), but O(decays)
+                // instead of O(increment), so huge increments can't hang.
                 let mut remaining_incr = increment;
-                while remaining_incr > 0 {
+                loop {
                     let current_count = self.buckets[i][bucket_idx].count;
                     let decay_threshold = self.decay_threshold(current_count);
-                    let rand = self.random.next_u64();
-                    let bucket = &mut self.buckets[i][bucket_idx];
-                    if rand < decay_threshold {
-                        bucket.count = bucket.count.saturating_sub(1);
-
-                        if bucket.count == 0 {
-                            bucket.fingerprint = composer.fingerprint();
-                            bucket.count = remaining_incr;
-                            max_count = std::cmp::max(max_count, bucket.count);
-                            break;
-                        }
+                    if decay_threshold == 0 {
+                        break;
                     }
-
-                    remaining_incr -= 1;
+                    let trials = sample_geometric(decay_threshold, &mut self.random);
+                    if trials > remaining_incr {
+                        // The next decay lands beyond this add's budget: the
+                        // remaining units are all failed trials.
+                        break;
+                    }
+                    let bucket = &mut self.buckets[i][bucket_idx];
+                    if bucket.count <= 1 {
+                        // Killing decay: the old loop broke before spending a
+                        // unit on the successful trial, so only the trials-1
+                        // failures before it consume budget.
+                        bucket.fingerprint = composer.fingerprint();
+                        bucket.count = remaining_incr - (trials - 1);
+                        max_count = std::cmp::max(max_count, bucket.count);
+                        break;
+                    }
+                    bucket.count -= 1;
+                    remaining_incr -= trials;
+                    if remaining_incr == 0 {
+                        break;
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,6 @@ pub use bucketed::{BucketedBuilderError, BucketedMergeError, BucketedNode, Bucke
 mod cuckoo;
 pub use cuckoo::{CuckooBuilderError, CuckooMergeError, CuckooNode, CuckooTopK};
 
+mod geometric;
 mod hash_composition;
 mod priority_queue;

--- a/tests/decay_semantics.rs
+++ b/tests/decay_semantics.rs
@@ -1,0 +1,77 @@
+//! Regression tests for batched-add decay semantics.
+//!
+//! HeavyKeeper's `add(item, n)` is defined as the sequential per-unit
+//! algorithm: it must behave as if the item arrived `n` times, one at a
+//! time. Each unit of increment is one decay trial against a colliding
+//! bucket; the decay probability is re-evaluated as the incumbent's count
+//! drops, and when the count reaches zero the challenger takes the bucket
+//! with the *unconsumed remainder* of the increment.
+
+use heavykeeper::TopK;
+
+/// With decay = 1.0 every trial decays, so the whole process is
+/// deterministic and batched vs. single-unit adds must agree exactly.
+///
+/// item1 holds the bucket with count 1000. Adding item2 with weight 3000
+/// spends 1000 units grinding item1 to zero, takes the bucket with the
+/// remainder, and ends at count 2001 — identical to calling
+/// add(item2, 1) 3000 times.
+#[test]
+fn batched_add_matches_single_unit_adds() {
+    let item1 = b"item1".to_vec();
+    let item2 = b"item2".to_vec();
+
+    // width=1, depth=1: both items share the single bucket.
+    let mut batched: TopK<Vec<u8>> = TopK::new(1, 1, 1, 1.0);
+    batched.add(&item1, 1000);
+    batched.add(&item2, 3000);
+
+    let mut singles: TopK<Vec<u8>> = TopK::new(1, 1, 1, 1.0);
+    singles.add(&item1, 1000);
+    for _ in 0..3000 {
+        singles.add(&item2, 1);
+    }
+
+    let b = batched.list();
+    let s = singles.list();
+    assert_eq!(b[0].item, item2);
+    assert_eq!(s[0].item, item2);
+    assert_eq!(
+        b[0].count, s[0].count,
+        "add(item, 3000) must agree with 3000 x add(item, 1): batched={} singles={}",
+        b[0].count, s[0].count
+    );
+    assert_eq!(
+        b[0].count, 2001,
+        "takeover count must be the unconsumed remainder of the increment"
+    );
+}
+
+/// A challenger whose weight is several times the expected eviction cost
+/// must take over the bucket.
+///
+/// item1 holds the bucket with count 120 (decay 0.9). The sequential
+/// process needs ~3.1M units on average to grind that to zero
+/// (sum of 0.9^-c for c in 1..=120), because the decay probability rises
+/// as the count drops. A 15M-unit add therefore evicts with overwhelming
+/// probability (failure odds < 1e-9, and the RNG is seeded, so the run is
+/// deterministic).
+///
+/// An implementation that freezes the decay probability at the initial
+/// count (p = 0.9^120 ~= 3.2e-6) expects only ~48 decays from 15M trials
+/// but needs 120 — a >10 sigma shortfall — so it essentially never evicts.
+#[test]
+fn heavy_challenger_evicts_incumbent() {
+    let item1 = b"item1".to_vec();
+    let item2 = b"item2".to_vec();
+
+    let mut topk: TopK<Vec<u8>> = TopK::new(1, 1, 1, 0.9);
+    topk.add(&item1, 120);
+    topk.add(&item2, 15_000_000);
+
+    let nodes = topk.list();
+    assert_eq!(
+        nodes[0].item, item2,
+        "a 15M-weight challenger must evict a 120-count incumbent"
+    );
+}

--- a/tests/decay_semantics.rs
+++ b/tests/decay_semantics.rs
@@ -7,7 +7,7 @@
 //! drops, and when the count reaches zero the challenger takes the bucket
 //! with the *unconsumed remainder* of the increment.
 
-use heavykeeper::TopK;
+use heavykeeper::{BucketedTopK, CuckooTopK, TopK};
 
 /// With decay = 1.0 every trial decays, so the whole process is
 /// deterministic and batched vs. single-unit adds must agree exactly.
@@ -74,4 +74,34 @@ fn heavy_challenger_evicts_incumbent() {
         nodes[0].item, item2,
         "a 15M-weight challenger must evict a 120-count incumbent"
     );
+}
+
+/// The motivating bug for the batched decay path: a colliding add with a
+/// huge increment must not iterate once per unit. The incumbent's count
+/// is high enough (decay^1e6 ~= 0) that the challenger cannot win the
+/// bucket, so the entire add is failed decay trials — the worst case for
+/// a per-unit loop, which would run u64::MAX iterations here.
+#[test]
+fn huge_increment_add_does_not_hang_topk() {
+    let mut topk: TopK<Vec<u8>> = TopK::new(1, 1, 1, 0.9);
+    topk.add(&b"alpha".to_vec(), 1_000_000);
+    topk.add(&b"beta".to_vec(), u64::MAX);
+    assert_eq!(topk.list()[0].item, b"alpha".to_vec());
+}
+
+#[test]
+fn huge_increment_add_does_not_hang_bucketed() {
+    let mut topk: BucketedTopK<Vec<u8>> = BucketedTopK::new(10, 1, 1, 0.9);
+    topk.add(&b"alpha".to_vec(), 1_000_000);
+    topk.add(&b"beta".to_vec(), u64::MAX);
+    assert!(topk.list().len() <= 10);
+}
+
+#[test]
+fn huge_increment_add_does_not_hang_cuckoo() {
+    let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 1, 1, 0.9);
+    topk.add(&b"hot".to_vec(), 1_000_000_000); // fills the heavy slot
+    topk.add(&b"alpha".to_vec(), 1_000_000); // stays in the lobby
+    topk.add(&b"beta".to_vec(), u64::MAX); // decays the occupied lobby
+    assert!(topk.list().len() <= 10);
 }


### PR DESCRIPTION
The `while remaining_incr > 0` loop in the decay path of `add_with_evicted` iterates approximately 1e19 times when `increment` is extremely large (e.g., `u64::MAX`), effectively hanging the calling thread. All three TopK variants (`TopK`, `BucketedTopK`, `CuckooTopK`) are affected.

Add `src/binomial.rs` → `sample_binomial(n, p, rng)`, which samples from Binomial(n, p) in O(1) expected time:

| n range | np(1-p) | Strategy | Complexity |
|---|---|---|---|
| n ≤ 10 | — | Direct simulation | O(n) |
| any | > 5.0 | Box-Muller normal approximation | O(1) |
| any | ≤ 5.0 | Knuth Poisson approximation | O(Poisson(np)) |

p > 0.5 is handled via complement symmetry: `n - sample_binomial(n, 1-p)`.

When `threshold = u64::MAX` (i.e., p = 1.0), the new code may overestimate the count (the difference can be as large as `cur`). This branch is never triggered in production where decay < 1.0.

All tests have been added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced decay logic for top‑k updates using more efficient probabilistic sampling to better handle large increments.
* **Bug Fixes**
  * Fixed scenarios where very large increments could cause updates to hang across multiple top‑k sketch variants.
  * Restored correct behavior for extreme decay/edge cases and improved deterministic decay=1.0 semantics.
  * Fixed a crate module conflict that could impact compilation.
* **Performance**
  * Reduced decay/eviction work per update, making high‑volume updates significantly faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->