### PR TITLE
feat: add byte serialization (save / load)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/lib.rs"
 
 [dependencies]
 rand = { version = "0.9.0", features = [ "small_rng" ] }
+rand_xoshiro = "0.8"
 ahash = "0.8.11"
 thiserror = "2.0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/lib.rs"
 
 
 [dependencies]
-rand = { version = "0.9.0", features = [ "small_rng" ] }
 rand_xoshiro = "0.8"
 ahash = "0.8.11"
 thiserror = "2.0.11"
@@ -33,6 +32,7 @@ debug = true
 criterion = "0.8.2"
 clap = { version = "4.5.19", features = ["derive"] }
 memmap2 = "0.9.5"
+rand = "0.9.0"
 rand_distr = "0.5"
 
 [[bench]]

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -78,6 +78,34 @@ pub enum BucketedBuilderError {
     InvalidDecay { decay: f64 },
 }
 
+#[derive(Error, Debug)]
+pub enum BucketedDeserializeError {
+    #[error(
+        "Byte stream too short while reading {field}: need {needed} more byte(s), have {actual}"
+    )]
+    UnexpectedEof {
+        field: &'static str,
+        needed: usize,
+        actual: usize,
+    },
+
+    #[error("Unsupported serialization version {version} (this build expects {expected})")]
+    UnsupportedVersion { version: u8, expected: u8 },
+
+    #[error("Invalid {field} value: {detail}")]
+    InvalidField { field: &'static str, detail: String },
+
+    #[error("Length mismatch for {field}: payload holds {actual} but expected {expected}")]
+    LengthMismatch {
+        field: &'static str,
+        actual: usize,
+        expected: usize,
+    },
+
+    #[error("{count} unexpected trailing byte(s) after the sketch payload")]
+    TrailingBytes { count: usize },
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Default, Debug)]
 struct Cell {
@@ -497,6 +525,204 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         let r = (count % divisor) as usize;
         let rem_thr = tbl[r] as f64 / u64::MAX as f64;
         ((last.powf(q) * rem_thr) * u64::MAX as f64) as u64
+    }
+}
+
+const VERSION: u8 = 1;
+const CELL_SIZE: usize = 16;
+const RNG_STATE_SIZE: usize = 32;
+
+/// Narrow a `u64` to `usize`, erroring on overflow.
+fn decoded_usize(value: u64, field: &'static str) -> Result<usize, BucketedDeserializeError> {
+    usize::try_from(value).map_err(|_| BucketedDeserializeError::InvalidField {
+        field,
+        detail: format!("value {value} exceeds usize range on this platform"),
+    })
+}
+
+/// Parse a `CELL_SIZE`-aligned slice into a boxed cell array.
+fn parse_cells(slice: &[u8]) -> Box<[Cell]> {
+    slice
+        .chunks_exact(CELL_SIZE)
+        .map(|chunk| Cell {
+            fingerprint: u64::from_le_bytes(chunk[0..8].try_into().expect("8 bytes")),
+            count: u64::from_le_bytes(chunk[8..16].try_into().expect("8 bytes")),
+        })
+        .collect()
+}
+
+/// Bounds-checked read of `n` bytes at `*pos`, advancing it.
+fn take<'a>(
+    bytes: &'a [u8],
+    pos: &mut usize,
+    n: usize,
+    field: &'static str,
+) -> Result<&'a [u8], BucketedDeserializeError> {
+    let available = bytes.len().saturating_sub(*pos);
+    if available < n {
+        return Err(BucketedDeserializeError::UnexpectedEof {
+            field,
+            needed: n,
+            actual: available,
+        });
+    }
+    let slice = &bytes[*pos..*pos + n];
+    *pos += n;
+    Ok(slice)
+}
+
+/// Read a little-endian `u64` at `*pos`, advancing it.
+fn take_u64(
+    bytes: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<u64, BucketedDeserializeError> {
+    Ok(u64::from_le_bytes(
+        take(bytes, pos, 8, field)?
+            .try_into()
+            .expect("slice is 8 bytes"),
+    ))
+}
+
+impl BucketedTopK<Vec<u8>> {
+    /// Serialize the sketch to a byte stream. Layout (little-endian):
+    ///
+    /// ```text
+    /// version: u8
+    /// width, depth, decay(bits), top_items: u64 each
+    /// cells:    width*depth  x (fingerprint: u64, count: u64)
+    /// pq_len: u64
+    /// pq:       pq_len       x (key_len: u64, key bytes, count: u64)
+    /// rng_state: 32 bytes
+    /// ```
+    ///
+    /// The seed is not stored; the hasher is rebuilt from the seed passed to
+    /// [`from_bytes`](BucketedTopK::from_bytes). The RNG position is stored
+    /// (`rng_state`) and restored exactly.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let pq_len = self.priority_queue.len();
+        let mut out = Vec::with_capacity(
+            1 + 8 * 4 + self.cells.len() * CELL_SIZE + pq_len * 24 + RNG_STATE_SIZE,
+        );
+
+        out.push(VERSION);
+        out.extend_from_slice(&(self.width as u64).to_le_bytes());
+        out.extend_from_slice(&(self.depth as u64).to_le_bytes());
+        out.extend_from_slice(&self.decay.to_bits().to_le_bytes());
+        out.extend_from_slice(&(self.top_items as u64).to_le_bytes());
+
+        for cell in self.cells.iter() {
+            out.extend_from_slice(&cell.fingerprint.to_le_bytes());
+            out.extend_from_slice(&cell.count.to_le_bytes());
+        }
+
+        // Serialize in insertion-`sequence` order (not count order) so restore
+        // preserves the count-tie ordering; see `TopKQueue::iter_by_sequence`.
+        out.extend_from_slice(&(pq_len as u64).to_le_bytes());
+        for (item, count) in self.priority_queue.iter_by_sequence() {
+            out.extend_from_slice(&(item.len() as u64).to_le_bytes());
+            out.extend_from_slice(item);
+            out.extend_from_slice(&count.to_le_bytes());
+        }
+        out.extend_from_slice(&self.rng.state());
+
+        out
+    }
+
+    /// Reconstruct a sketch from [`to_bytes`](BucketedTopK::to_bytes) output.
+    /// `seed` must match the sketch's original seed; the hasher rebuilt from it.
+    pub fn from_bytes(bytes: &[u8], seed: u64) -> Result<Self, BucketedDeserializeError> {
+        let mut pos = 0;
+
+        let version = take(bytes, &mut pos, 1, "version")?[0];
+        if version != VERSION {
+            return Err(BucketedDeserializeError::UnsupportedVersion {
+                version,
+                expected: VERSION,
+            });
+        }
+        let width = decoded_usize(take_u64(bytes, &mut pos, "width")?, "width")?;
+        let depth = decoded_usize(take_u64(bytes, &mut pos, "depth")?, "depth")?;
+        let decay = f64::from_bits(take_u64(bytes, &mut pos, "decay")?);
+        let top_items = decoded_usize(take_u64(bytes, &mut pos, "top_items")?, "top_items")?;
+
+        // Validate scalars before sizing anything off them.
+        if width < 1 {
+            return Err(BucketedDeserializeError::InvalidField {
+                field: "width",
+                detail: format!("must be >= 1, got {width}"),
+            });
+        }
+        if depth < 1 {
+            return Err(BucketedDeserializeError::InvalidField {
+                field: "depth",
+                detail: format!("must be >= 1, got {depth}"),
+            });
+        }
+        if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
+            return Err(BucketedDeserializeError::InvalidField {
+                field: "decay",
+                detail: format!("must be a finite value in 0.0..=1.0, got {decay}"),
+            });
+        }
+
+        // `take` checks the bytes exist before `parse_cells` allocates, so a
+        // corrupt geometry can't force a huge allocation.
+        let cell_count =
+            width
+                .checked_mul(depth)
+                .ok_or_else(|| BucketedDeserializeError::InvalidField {
+                    field: "width*depth",
+                    detail: format!("overflows usize ({width} * {depth})"),
+                })?;
+        let cell_bytes = cell_count.checked_mul(CELL_SIZE).ok_or_else(|| {
+            BucketedDeserializeError::InvalidField {
+                field: "cells",
+                detail: format!("size overflows usize (width*depth={cell_count})"),
+            }
+        })?;
+        let cells = parse_cells(take(bytes, &mut pos, cell_bytes, "cells")?);
+
+        let pq_len = decoded_usize(
+            take_u64(bytes, &mut pos, "priority_queue length")?,
+            "priority_queue length",
+        )?;
+        if pq_len > top_items {
+            return Err(BucketedDeserializeError::LengthMismatch {
+                field: "priority queue",
+                actual: pq_len,
+                expected: top_items,
+            });
+        }
+
+        // The `top_items` reserve is an unbounded-header OOM tradeoff; see
+        // `CuckooTopK::from_bytes`.
+        let mut sketch = Self::with_seed(top_items, width, depth, decay, seed);
+        sketch.cells = cells;
+
+        for _ in 0..pq_len {
+            let key_len = decoded_usize(
+                take_u64(bytes, &mut pos, "priority_queue key length")?,
+                "priority_queue key length",
+            )?;
+            let item = take(bytes, &mut pos, key_len, "priority_queue key")?.to_vec();
+            let count = take_u64(bytes, &mut pos, "priority_queue count")?;
+            sketch.priority_queue.upsert(item, count);
+        }
+        sketch.min_pq_count = sketch.priority_queue.min_count();
+
+        let rng_state: [u8; RNG_STATE_SIZE] = take(bytes, &mut pos, RNG_STATE_SIZE, "rng_state")?
+            .try_into()
+            .expect("slice is RNG_STATE_SIZE bytes");
+        sketch.rng = Xoshiro256PlusPlus::from_seed(rng_state);
+
+        if pos != bytes.len() {
+            return Err(BucketedDeserializeError::TrailingBytes {
+                count: bytes.len() - pos,
+            });
+        }
+
+        Ok(sketch)
     }
 }
 
@@ -1182,5 +1408,168 @@ mod tests {
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
         assert_eq!(topk.add_with_evicted(&b"cold".to_vec(), 10), (None, false));
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_preserves_state() {
+        let mut original = BucketedTopK::<Vec<u8>>::with_seed(50, 64, 4, 0.9, 42);
+        for i in 0u32..200 {
+            original.add(&format!("key-{i}").into_bytes(), (i as u64) + 1);
+        }
+        let restored =
+            BucketedTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        assert_eq!(restored.width, original.width);
+        assert_eq!(restored.depth, original.depth);
+        assert_eq!(restored.decay, original.decay);
+        assert_eq!(restored.top_items, original.top_items);
+        assert_eq!(restored.list(), original.list());
+        for i in 0u32..200 {
+            let key = format!("key-{i}").into_bytes();
+            assert_eq!(
+                restored.count(&key),
+                original.count(&key),
+                "count mismatch for {key:?}"
+            );
+            assert_eq!(
+                restored.bucket_count(&key),
+                original.bucket_count(&key),
+                "bucket_count mismatch for {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_empty_sketch() {
+        let original = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 7);
+        let restored =
+            BucketedTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 7).expect("round-trips");
+        assert_eq!(restored.list(), original.list());
+        assert!(restored.list().is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_truncated_stream() {
+        let mut sketch = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        sketch.add(b"foo".as_slice(), 5);
+        let bytes = sketch.to_bytes();
+        let Err(err) = BucketedTopK::<Vec<u8>>::from_bytes(&bytes[..bytes.len() - 1], 42) else {
+            panic!("truncated stream must fail");
+        };
+        assert!(matches!(
+            err,
+            BucketedDeserializeError::UnexpectedEof { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_trailing_bytes() {
+        let mut bytes = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes.push(0xff);
+        let Err(err) = BucketedTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("trailing bytes must fail");
+        };
+        assert!(matches!(
+            err,
+            BucketedDeserializeError::TrailingBytes { count: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_unsupported_version() {
+        let mut bytes = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes[0] = VERSION + 1;
+        let Err(err) = BucketedTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("bad version must fail");
+        };
+        assert!(matches!(
+            err,
+            BucketedDeserializeError::UnsupportedVersion { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_zero_width() {
+        let mut bytes = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        // width is the first u64 right after the 1-byte version.
+        bytes[1..9].copy_from_slice(&0u64.to_le_bytes());
+        let Err(err) = BucketedTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("zero width must fail");
+        };
+        assert!(matches!(
+            err,
+            BucketedDeserializeError::InvalidField { field: "width", .. }
+        ));
+    }
+
+    /// Regression: a restored sketch must resume the RNG where the original
+    /// left off, or identical follow-up traffic makes them diverge (the
+    /// primary/replica full-sync case).
+    #[test]
+    fn test_serialize_preserves_rng_position_no_divergence() {
+        // Small width + high decay churn forces the decay path to consume RNG.
+        let mut original = BucketedTopK::<Vec<u8>>::with_seed(20, 16, 2, 0.9, 42);
+        for i in 0u32..500 {
+            original.add(&format!("warmup-{}", i % 40).into_bytes(), 3);
+        }
+
+        let mut restored =
+            BucketedTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Feed identical follow-up traffic to both copies.
+        for i in 0u32..500 {
+            let key = format!("live-{}", i % 40).into_bytes();
+            original.add(&key, 3);
+            restored.add(&key, 3);
+        }
+
+        // Full state (incl. rng_state) is more sensitive than `list()` alone.
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
+    }
+
+    #[test]
+    fn test_serialize_appends_rng_state() {
+        let empty = BucketedTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        let bytes = empty.to_bytes();
+        // Header (version + 4 u64s) + cells + pq_len + rng state.
+        let header = 1 + 8 * 4;
+        let cells = 64 * 4 * CELL_SIZE;
+        let pq_len = 8;
+        assert_eq!(bytes.len(), header + cells + pq_len + RNG_STATE_SIZE);
+    }
+
+    /// Regression: equal-count items must keep their order across a round-trip.
+    /// `a` is inserted first but has the lower count at snapshot time; count-order
+    /// serialization would flip the tie once follow-up traffic levels the counts.
+    #[test]
+    fn test_serialize_preserves_pq_tie_order() {
+        // Wide sketch so fingerprints don't collide and counts stay exact.
+        let mut original = BucketedTopK::<Vec<u8>>::with_seed(4, 1024, 4, 0.9, 42);
+        original.add(b"a".as_slice(), 10); // inserted first (lower sequence)
+        original.add(b"b".as_slice(), 20); // inserted second, higher count
+
+        let mut restored =
+            BucketedTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Identical follow-up traffic levels the counts, forming a tie.
+        original.add(b"a".as_slice(), 10);
+        restored.add(b"a".as_slice(), 10);
+
+        let order =
+            |s: &BucketedTopK<Vec<u8>>| s.list().into_iter().map(|n| n.item).collect::<Vec<_>>();
+        assert_eq!(
+            order(&restored),
+            order(&original),
+            "equal-count items must keep their order across a round-trip"
+        );
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
     }
 }

--- a/src/bucketed.rs
+++ b/src/bucketed.rs
@@ -7,8 +7,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use ahash::RandomState;
-use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+// Import RNG traits from `rand_xoshiro`'s re-exported `rand_core` (0.10, not the
+// 0.9 `rand` uses); in 0.10 `next_u64` is on `Rng`, not `RngCore`.
+use rand_xoshiro::rand_core::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
 use thiserror::Error;
 
 use crate::priority_queue::TopKQueue;
@@ -102,7 +104,7 @@ pub struct BucketedTopK<T: Ord + Clone + Hash> {
     decay_thresholds: Box<[u64]>,
     priority_queue: TopKQueue<T>,
     hasher: RandomState,
-    rng: SmallRng,
+    rng: Xoshiro256PlusPlus,
     min_pq_count: u64,
     top_items: usize,
 }
@@ -125,7 +127,14 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         decay: f64,
         hasher: RandomState,
     ) -> Self {
-        Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(0))
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            Xoshiro256PlusPlus::seed_from_u64(0),
+        )
     }
 
     pub fn builder() -> BucketedBuilder<T> {
@@ -138,7 +147,7 @@ impl<T: Ord + Clone + Hash> BucketedTopK<T> {
         depth: usize,
         decay: f64,
         hasher: RandomState,
-        rng: SmallRng,
+        rng: Xoshiro256PlusPlus,
     ) -> Self {
         let priority_queue = TopKQueue::with_capacity_and_hasher(k, hasher.clone());
         let width_mask = if width > 1 && width.is_power_of_two() {
@@ -590,7 +599,7 @@ impl<T: Ord + Clone + Hash> BucketedBuilder<T> {
                 RandomState::new()
             }
         });
-        let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
+        let rng = Xoshiro256PlusPlus::seed_from_u64(self.seed.unwrap_or(0));
         Ok(BucketedTopK::with_components(
             k, width, depth, decay, hasher, rng,
         ))

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -58,6 +58,34 @@ pub enum CuckooMergeError {
 }
 
 #[derive(Error, Debug)]
+pub enum CuckooDeserializeError {
+    #[error(
+        "Byte stream too short while reading {field}: need {needed} more byte(s), have {actual}"
+    )]
+    UnexpectedEof {
+        field: &'static str,
+        needed: usize,
+        actual: usize,
+    },
+
+    #[error("Unsupported serialization version {version} (this build expects {expected})")]
+    UnsupportedVersion { version: u8, expected: u8 },
+
+    #[error("Invalid {field} value: {detail}")]
+    InvalidField { field: &'static str, detail: String },
+
+    #[error("Length mismatch for {field}: payload holds {actual} but expected {expected}")]
+    LengthMismatch {
+        field: &'static str,
+        actual: usize,
+        expected: usize,
+    },
+
+    #[error("{count} unexpected trailing byte(s) after the sketch payload")]
+    TrailingBytes { count: usize },
+}
+
+#[derive(Error, Debug)]
 pub enum CuckooBuilderError {
     #[error("Missing required field: {field}")]
     MissingField { field: String },
@@ -763,6 +791,219 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
     }
 }
 
+const VERSION: u8 = 1;
+const CELL_SIZE: usize = 16;
+
+/// Narrow a `u64` to `usize`, erroring on overflow.
+fn decoded_usize(value: u64, field: &'static str) -> Result<usize, CuckooDeserializeError> {
+    usize::try_from(value).map_err(|_| CuckooDeserializeError::InvalidField {
+        field,
+        detail: format!("value {value} exceeds usize range on this platform"),
+    })
+}
+
+/// Parse a `CELL_SIZE`-aligned slice into a boxed cell array.
+fn parse_cells(slice: &[u8]) -> Box<[Cell]> {
+    slice
+        .chunks_exact(CELL_SIZE)
+        .map(|chunk| Cell {
+            fingerprint: u64::from_le_bytes(chunk[0..8].try_into().expect("8 bytes")),
+            count: u64::from_le_bytes(chunk[8..16].try_into().expect("8 bytes")),
+        })
+        .collect()
+}
+
+/// Bounds-checked read of `n` bytes at `*pos`, advancing it.
+fn take<'a>(
+    bytes: &'a [u8],
+    pos: &mut usize,
+    n: usize,
+    field: &'static str,
+) -> Result<&'a [u8], CuckooDeserializeError> {
+    if bytes.len() - *pos < n {
+        return Err(CuckooDeserializeError::UnexpectedEof {
+            field,
+            needed: n,
+            actual: bytes.len() - *pos,
+        });
+    }
+    let slice = &bytes[*pos..*pos + n];
+    *pos += n;
+    Ok(slice)
+}
+
+/// Read a little-endian `u64` at `*pos`, advancing it.
+fn take_u64(
+    bytes: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<u64, CuckooDeserializeError> {
+    Ok(u64::from_le_bytes(
+        take(bytes, pos, 8, field)?
+            .try_into()
+            .expect("slice is 8 bytes"),
+    ))
+}
+
+impl CuckooTopK<Vec<u8>> {
+    /// Serialize the sketch to a byte stream. Layout (little-endian):
+    ///
+    /// ```text
+    /// version: u8
+    /// width, depth, decay(bits), top_items, max_kicks: u64 each
+    /// lobbies:  width        x (fingerprint: u64, count: u64)
+    /// heavy:    width*depth  x (fingerprint: u64, count: u64)
+    /// pq_len: u64
+    /// pq:       pq_len       x (key_len: u64, key bytes, count: u64)
+    /// ```
+    ///
+    /// The seed is not stored; pass it to [`from_bytes`](CuckooTopK::from_bytes).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let cell_count = self.lobbies.len() + self.heavy.len();
+        let pq_len = self.priority_queue.len();
+        // Capacity hint: header (version + 6 u64s) + cells + pq estimate.
+        let mut out = Vec::with_capacity(1 + 8 * 6 + cell_count * CELL_SIZE + pq_len * 24);
+
+        out.push(VERSION);
+        out.extend_from_slice(&(self.width as u64).to_le_bytes());
+        out.extend_from_slice(&(self.depth as u64).to_le_bytes());
+        out.extend_from_slice(&self.decay.to_bits().to_le_bytes());
+        out.extend_from_slice(&(self.top_items as u64).to_le_bytes());
+        out.extend_from_slice(&(self.max_kicks as u64).to_le_bytes());
+
+        for cell in self.lobbies.iter().chain(self.heavy.iter()) {
+            out.extend_from_slice(&cell.fingerprint.to_le_bytes());
+            out.extend_from_slice(&cell.count.to_le_bytes());
+        }
+
+        out.extend_from_slice(&(pq_len as u64).to_le_bytes());
+        for (item, count) in self.priority_queue.iter() {
+            out.extend_from_slice(&(item.len() as u64).to_le_bytes());
+            out.extend_from_slice(item);
+            out.extend_from_slice(&count.to_le_bytes());
+        }
+
+        out
+    }
+
+    /// Reconstruct a sketch from [`to_bytes`](CuckooTopK::to_bytes) output.
+    /// `seed` must match the sketch's original seed; the hasher and RNG are
+    /// rebuilt from it.
+    pub fn from_bytes(bytes: &[u8], seed: u64) -> Result<Self, CuckooDeserializeError> {
+        let mut pos = 0;
+
+        // Header.
+        let version = take(bytes, &mut pos, 1, "version")?[0];
+        if version != VERSION {
+            return Err(CuckooDeserializeError::UnsupportedVersion {
+                version,
+                expected: VERSION,
+            });
+        }
+        let width = decoded_usize(take_u64(bytes, &mut pos, "width")?, "width")?;
+        let depth = decoded_usize(take_u64(bytes, &mut pos, "depth")?, "depth")?;
+        let decay = f64::from_bits(take_u64(bytes, &mut pos, "decay")?);
+        let top_items = decoded_usize(take_u64(bytes, &mut pos, "top_items")?, "top_items")?;
+        let max_kicks = decoded_usize(take_u64(bytes, &mut pos, "max_kicks")?, "max_kicks")?;
+
+        // Validate scalars before sizing anything off them.
+        if width < 1 {
+            return Err(CuckooDeserializeError::InvalidField {
+                field: "width",
+                detail: format!("must be >= 1, got {width}"),
+            });
+        }
+        if depth < 1 {
+            return Err(CuckooDeserializeError::InvalidField {
+                field: "depth",
+                detail: format!("must be >= 1, got {depth}"),
+            });
+        }
+        if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
+            return Err(CuckooDeserializeError::InvalidField {
+                field: "decay",
+                detail: format!("must be a finite value in 0.0..=1.0, got {decay}"),
+            });
+        }
+        if max_kicks < 1 {
+            return Err(CuckooDeserializeError::InvalidField {
+                field: "max_kicks",
+                detail: format!("must be >= 1, got {max_kicks}"),
+            });
+        }
+
+        let expected_heavy =
+            width
+                .checked_mul(depth)
+                .ok_or_else(|| CuckooDeserializeError::InvalidField {
+                    field: "width*depth",
+                    detail: format!("overflows usize ({width} * {depth})"),
+                })?;
+
+        // Cells: `take` checks the bytes exist before `parse_cells` allocates,
+        // so a corrupt geometry can't force a huge allocation.
+        let lobby_bytes =
+            width
+                .checked_mul(CELL_SIZE)
+                .ok_or_else(|| CuckooDeserializeError::InvalidField {
+                    field: "lobbies",
+                    detail: format!("size overflows usize (width={width})"),
+                })?;
+        let lobbies = parse_cells(take(bytes, &mut pos, lobby_bytes, "lobbies")?);
+        let heavy_bytes = expected_heavy.checked_mul(CELL_SIZE).ok_or_else(|| {
+            CuckooDeserializeError::InvalidField {
+                field: "heavy",
+                detail: format!("size overflows usize (width*depth={expected_heavy})"),
+            }
+        })?;
+        let heavy = parse_cells(take(bytes, &mut pos, heavy_bytes, "heavy")?);
+
+        // Priority queue: a length prefix, then variable-length entries.
+        let pq_len = decoded_usize(
+            take_u64(bytes, &mut pos, "priority_queue length")?,
+            "priority_queue length",
+        )?;
+        if pq_len > top_items {
+            return Err(CuckooDeserializeError::LengthMismatch {
+                field: "priority queue",
+                actual: pq_len,
+                expected: top_items,
+            });
+        }
+
+        // Rebuild the seed-derived state, then graft the cells and queue on top.
+        // Build the priority queue empty (capacity 0) rather than pre-reserving
+        // `top_items` slots: a corrupt `top_items` then cannot force a huge
+        // allocation. The queue grows on demand as the `pq_len` entries below
+        // are inserted, and the real `k` is restored via `set_capacity`.
+        let mut sketch = Self::with_seed(0, width, depth, decay, seed);
+        sketch.max_kicks = max_kicks;
+        sketch.lobbies = lobbies;
+        sketch.heavy = heavy;
+        sketch.top_items = top_items;
+        sketch.priority_queue.set_capacity(top_items);
+
+        for _ in 0..pq_len {
+            let key_len = decoded_usize(
+                take_u64(bytes, &mut pos, "priority_queue key length")?,
+                "priority_queue key length",
+            )?;
+            let item = take(bytes, &mut pos, key_len, "priority_queue key")?.to_vec();
+            let count = take_u64(bytes, &mut pos, "priority_queue count")?;
+            sketch.priority_queue.upsert(item, count);
+        }
+        sketch.min_pq_count = sketch.priority_queue.min_count();
+
+        if pos != bytes.len() {
+            return Err(CuckooDeserializeError::TrailingBytes {
+                count: bytes.len() - pos,
+            });
+        }
+
+        Ok(sketch)
+    }
+}
+
 pub struct CuckooBuilder<T> {
     k: Option<usize>,
     width: Option<usize>,
@@ -881,8 +1122,14 @@ mod tests {
     fn test_query_alias_delegates_to_contains() {
         let mut topk: CuckooTopK<Vec<u8>> = CuckooTopK::new(10, 64, 3, 0.9);
         topk.add(b"alpha".as_slice(), 5);
-        assert_eq!(topk.query(b"alpha".as_slice()), topk.contains(b"alpha".as_slice()));
-        assert_eq!(topk.query(b"missing".as_slice()), topk.contains(b"missing".as_slice()));
+        assert_eq!(
+            topk.query(b"alpha".as_slice()),
+            topk.contains(b"alpha".as_slice())
+        );
+        assert_eq!(
+            topk.query(b"missing".as_slice()),
+            topk.contains(b"missing".as_slice())
+        );
     }
 
     #[test]

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -12,8 +12,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use ahash::RandomState;
-use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+// Import RNG traits from `rand_xoshiro`'s re-exported `rand_core` (0.10, not the
+// 0.9 `rand` uses); in 0.10 `next_u64` is on `Rng`, not `RngCore`.
+use rand_xoshiro::rand_core::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
 use thiserror::Error;
 
 use crate::priority_queue::TopKQueue;
@@ -160,7 +162,7 @@ pub struct CuckooTopK<T: Ord + Clone + Hash> {
     decay_thresholds: Box<[u64]>,
     priority_queue: TopKQueue<T>,
     hasher: RandomState,
-    rng: SmallRng,
+    rng: Xoshiro256PlusPlus,
     min_pq_count: u64,
     top_items: usize,
     max_kicks: usize,
@@ -187,7 +189,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
             depth,
             decay,
             hasher,
-            SmallRng::seed_from_u64(seed),
+            Xoshiro256PlusPlus::seed_from_u64(seed),
             DEFAULT_MAX_CUCKOO_KICKS,
         )
     }
@@ -209,7 +211,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
             depth,
             decay,
             hasher,
-            SmallRng::seed_from_u64(0),
+            Xoshiro256PlusPlus::seed_from_u64(0),
             DEFAULT_MAX_CUCKOO_KICKS,
         )
     }
@@ -225,7 +227,7 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
         depth: usize,
         decay: f64,
         hasher: RandomState,
-        rng: SmallRng,
+        rng: Xoshiro256PlusPlus,
         max_kicks: usize,
     ) -> Self {
         let width_mask = if width > 1 && width.is_power_of_two() {
@@ -802,6 +804,8 @@ impl<T: Ord + Clone + Hash> CuckooTopK<T> {
 
 const VERSION: u8 = 1;
 const CELL_SIZE: usize = 16;
+/// Bytes in a serialized `Xoshiro256PlusPlus` state (256-bit, little-endian).
+const RNG_STATE_SIZE: usize = 32;
 
 /// Narrow a `u64` to `usize`, erroring on overflow.
 fn decoded_usize(value: u64, field: &'static str) -> Result<usize, CuckooDeserializeError> {
@@ -865,14 +869,18 @@ impl CuckooTopK<Vec<u8>> {
     /// heavy:    width*depth  x (fingerprint: u64, count: u64)
     /// pq_len: u64
     /// pq:       pq_len       x (key_len: u64, key bytes, count: u64)
+    /// rng_state: 32 bytes
     /// ```
     ///
-    /// The seed is not stored; pass it to [`from_bytes`](CuckooTopK::from_bytes).
+    /// The seed is not stored; the hasher is rebuilt from the seed passed to
+    /// [`from_bytes`](CuckooTopK::from_bytes). The RNG position is stored 
+    /// (`rng_state`) and restored exactly.
     pub fn to_bytes(&self) -> Vec<u8> {
         let cell_count = self.lobbies.len() + self.heavy.len();
         let pq_len = self.priority_queue.len();
-        // Capacity hint: header (version + 6 u64s) + cells + pq estimate.
-        let mut out = Vec::with_capacity(1 + 8 * 6 + cell_count * CELL_SIZE + pq_len * 24);
+        // Capacity hint: header (version + 5 u64s) + cells + pq_len u64 + pq estimate + rng.
+        let mut out =
+            Vec::with_capacity(1 + 8 * 6 + cell_count * CELL_SIZE + pq_len * 24 + RNG_STATE_SIZE);
 
         out.push(VERSION);
         out.extend_from_slice(&(self.width as u64).to_le_bytes());
@@ -892,13 +900,13 @@ impl CuckooTopK<Vec<u8>> {
             out.extend_from_slice(item);
             out.extend_from_slice(&count.to_le_bytes());
         }
+        out.extend_from_slice(&self.rng.state());
 
         out
     }
 
     /// Reconstruct a sketch from [`to_bytes`](CuckooTopK::to_bytes) output.
-    /// `seed` must match the sketch's original seed; the hasher and RNG are
-    /// rebuilt from it.
+    /// `seed` must match the sketch's original seed; the hasher rebuilt from it.
     pub fn from_bytes(bytes: &[u8], seed: u64) -> Result<Self, CuckooDeserializeError> {
         let mut pos = 0;
 
@@ -1005,6 +1013,12 @@ impl CuckooTopK<Vec<u8>> {
         }
         sketch.min_pq_count = sketch.priority_queue.min_count();
 
+        // Restore the RNG position. 
+        let rng_state: [u8; RNG_STATE_SIZE] = take(bytes, &mut pos, RNG_STATE_SIZE, "rng_state")?
+            .try_into()
+            .expect("slice is RNG_STATE_SIZE bytes");
+        sketch.rng = Xoshiro256PlusPlus::from_seed(rng_state);
+
         if pos != bytes.len() {
             return Err(CuckooDeserializeError::TrailingBytes {
                 count: bytes.len() - pos,
@@ -1109,7 +1123,7 @@ impl<T: Ord + Clone + Hash> CuckooBuilder<T> {
                 RandomState::new()
             }
         });
-        let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
+        let rng = Xoshiro256PlusPlus::seed_from_u64(self.seed.unwrap_or(0));
         Ok(CuckooTopK::with_components(
             k, width, depth, decay, hasher, rng, max_kicks,
         ))
@@ -1784,5 +1798,45 @@ mod tests {
             err,
             CuckooDeserializeError::InvalidField { field: "width", .. }
         ));
+    }
+
+    /// Regression: a restored sketch must resume the RNG where the original
+    /// left off, or identical follow-up traffic makes them diverge (the
+    /// primary/replica full-sync case).
+    #[test]
+    fn test_serialize_preserves_rng_position_no_divergence() {
+        // Small width + high decay churn forces the decay path to consume RNG.
+        let mut original = CuckooTopK::<Vec<u8>>::with_seed(20, 16, 2, 0.9, 42);
+        for i in 0u32..500 {
+            original.add(&format!("warmup-{}", i % 40).into_bytes(), 3);
+        }
+
+        let mut restored =
+            CuckooTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Feed identical follow-up traffic to both copies.
+        for i in 0u32..500 {
+            let key = format!("live-{}", i % 40).into_bytes();
+            original.add(&key, 3);
+            restored.add(&key, 3);
+        }
+
+        // Full state (incl. rng_state) is more sensitive than `list()` alone.
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
+    }
+
+    #[test]
+    fn test_serialize_appends_rng_state() {
+        let empty = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        let bytes = empty.to_bytes();
+        // Header (version + 5 u64s) + lobbies + heavy + pq_len + rng state.
+        let header = 1 + 8 * 5;
+        let cells = (64 + 64 * 4) * CELL_SIZE;
+        let pq_len = 8;
+        assert_eq!(bytes.len(), header + cells + pq_len + RNG_STATE_SIZE);
     }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -1680,4 +1680,94 @@ mod tests {
         assert!(topk.contains_top_k("foo"));
         assert!(!topk.contains_top_k("bar"));
     }
+
+    #[test]
+    fn test_serialize_roundtrip_preserves_state() {
+        let mut original = CuckooTopK::<Vec<u8>>::with_seed(50, 64, 4, 0.9, 42);
+        for i in 0u32..200 {
+            original.add(&format!("key-{i}").into_bytes(), (i as u64) + 1);
+        }
+        let restored =
+            CuckooTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        assert_eq!(restored.width(), original.width());
+        assert_eq!(restored.depth(), original.depth());
+        assert_eq!(restored.decay(), original.decay());
+        assert_eq!(restored.top_items(), original.top_items());
+        assert_eq!(restored.max_kicks(), original.max_kicks());
+        assert_eq!(restored.list(), original.list());
+        for i in 0u32..200 {
+            let key = format!("key-{i}").into_bytes();
+            assert_eq!(
+                restored.count(&key),
+                original.count(&key),
+                "count mismatch for {key:?}"
+            );
+            assert_eq!(
+                restored.bucket_count(&key),
+                original.bucket_count(&key),
+                "bucket_count mismatch for {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_empty_sketch() {
+        let original = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 7);
+        let restored =
+            CuckooTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 7).expect("round-trips");
+        assert_eq!(restored.list(), original.list());
+        assert!(restored.list().is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_truncated_stream() {
+        let mut sketch = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        sketch.add(b"foo".as_slice(), 5);
+        let bytes = sketch.to_bytes();
+        let Err(err) = CuckooTopK::<Vec<u8>>::from_bytes(&bytes[..bytes.len() - 1], 42) else {
+            panic!("truncated stream must fail");
+        };
+        assert!(matches!(err, CuckooDeserializeError::UnexpectedEof { .. }));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_trailing_bytes() {
+        let mut bytes = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes.push(0xff);
+        let Err(err) = CuckooTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("trailing bytes must fail");
+        };
+        assert!(matches!(
+            err,
+            CuckooDeserializeError::TrailingBytes { count: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_unsupported_version() {
+        let mut bytes = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes[0] = VERSION + 1;
+        let Err(err) = CuckooTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("bad version must fail");
+        };
+        assert!(matches!(
+            err,
+            CuckooDeserializeError::UnsupportedVersion { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_zero_width() {
+        let mut bytes = CuckooTopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        // width is the first u64 right after the 1-byte version.
+        bytes[1..9].copy_from_slice(&0u64.to_le_bytes());
+        let Err(err) = CuckooTopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("zero width must fail");
+        };
+        assert!(matches!(
+            err,
+            CuckooDeserializeError::InvalidField { field: "width", .. }
+        ));
+    }
 }

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -829,11 +829,12 @@ fn take<'a>(
     n: usize,
     field: &'static str,
 ) -> Result<&'a [u8], CuckooDeserializeError> {
-    if bytes.len() - *pos < n {
+    let available = bytes.len().saturating_sub(*pos);
+    if available < n {
         return Err(CuckooDeserializeError::UnexpectedEof {
             field,
             needed: n,
-            actual: bytes.len() - *pos,
+            actual: available,
         });
     }
     let slice = &bytes[*pos..*pos + n];
@@ -981,16 +982,17 @@ impl CuckooTopK<Vec<u8>> {
         }
 
         // Rebuild the seed-derived state, then graft the cells and queue on top.
-        // Build the priority queue empty (capacity 0) rather than pre-reserving
-        // `top_items` slots: a corrupt `top_items` then cannot force a huge
-        // allocation. The queue grows on demand as the `pq_len` entries below
-        // are inserted, and the real `k` is restored via `set_capacity`.
-        let mut sketch = Self::with_seed(0, width, depth, decay, seed);
+        // Reserve the original `top_items` capacity so a round-trip is identical
+        // in size to the original.
+        //
+        // OOM TRADEOFF: unlike the cell/key allocations (gated by `take`), this
+        // is sized by the unbounded `top_items` header, so a tampered stream
+        // could force a huge reserve. Fine for restoring our own dumps (RDB); if
+        // ever fed untrusted bytes, bound `top_items` first.
+        let mut sketch = Self::with_seed(top_items, width, depth, decay, seed);
         sketch.max_kicks = max_kicks;
         sketch.lobbies = lobbies;
         sketch.heavy = heavy;
-        sketch.top_items = top_items;
-        sketch.priority_queue.set_capacity(top_items);
 
         for _ in 0..pq_len {
             let key_len = decoded_usize(

--- a/src/cuckoo.rs
+++ b/src/cuckoo.rs
@@ -895,7 +895,7 @@ impl CuckooTopK<Vec<u8>> {
         }
 
         out.extend_from_slice(&(pq_len as u64).to_le_bytes());
-        for (item, count) in self.priority_queue.iter() {
+        for (item, count) in self.priority_queue.iter_by_sequence() {
             out.extend_from_slice(&(item.len() as u64).to_le_bytes());
             out.extend_from_slice(item);
             out.extend_from_slice(&count.to_le_bytes());
@@ -1838,5 +1838,37 @@ mod tests {
         let cells = (64 + 64 * 4) * CELL_SIZE;
         let pq_len = 8;
         assert_eq!(bytes.len(), header + cells + pq_len + RNG_STATE_SIZE);
+    }
+
+    /// Regression: equal-count items must keep their order across a round-trip.
+    /// `a` is inserted first but has the lower count at snapshot time; count-order
+    /// serialization would flip the tie once follow-up traffic levels the counts.
+    #[test]
+    fn test_serialize_preserves_pq_tie_order() {
+        // Wide sketch so fingerprints don't collide and counts stay exact.
+        let mut original = CuckooTopK::<Vec<u8>>::with_seed(4, 1024, 4, 0.9, 42);
+        original.add(b"a".as_slice(), 10); // inserted first (lower sequence)
+        original.add(b"b".as_slice(), 20); // inserted second, higher count
+
+        let mut restored =
+            CuckooTopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Identical follow-up traffic levels the counts, forming a tie.
+        original.add(b"a".as_slice(), 10);
+        restored.add(b"a".as_slice(), 10);
+
+        let order = |s: &CuckooTopK<Vec<u8>>| {
+            s.list().into_iter().map(|n| n.item).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            order(&restored),
+            order(&original),
+            "equal-count items must keep their order across a round-trip"
+        );
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
     }
 }

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -1,8 +1,10 @@
 use crate::hash_composition::HashComposer;
 use crate::priority_queue::TopKQueue;
 use ahash::RandomState;
-use rand::rngs::SmallRng;
-use rand::{RngCore, SeedableRng};
+// Import RNG traits from `rand_xoshiro`'s re-exported `rand_core` (0.10, not the
+// 0.9 `rand` uses); in 0.10 `next_u64` is on `Rng`, not `RngCore`.
+use rand_xoshiro::rand_core::{Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
 use std::borrow::Borrow;
 use std::clone::Clone;
 use std::fmt::Debug;
@@ -79,7 +81,7 @@ pub struct TopK<T: Ord + Clone + Hash> {
     buckets: Vec<Vec<Bucket>>,
     priority_queue: TopKQueue<T>,
     hasher: RandomState,
-    random: SmallRng,
+    random: Xoshiro256PlusPlus,
 }
 
 pub struct Builder<T> {
@@ -117,7 +119,14 @@ impl<T: Ord + Clone + Hash> TopK<T> {
     // New constructor that takes a seed
     pub fn with_seed(k: usize, width: usize, depth: usize, decay: f64, seed: u64) -> Self {
         let hasher = RandomState::with_seeds(seed, seed, seed, seed);
-        Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(seed))
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            Xoshiro256PlusPlus::seed_from_u64(seed),
+        )
     }
 
     pub fn with_hasher(
@@ -127,7 +136,14 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         decay: f64,
         hasher: RandomState,
     ) -> Self {
-        Self::with_components(k, width, depth, decay, hasher, SmallRng::seed_from_u64(0))
+        Self::with_components(
+            k,
+            width,
+            depth,
+            decay,
+            hasher,
+            Xoshiro256PlusPlus::seed_from_u64(0),
+        )
     }
 
     fn with_components(
@@ -136,7 +152,7 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         depth: usize,
         decay: f64,
         hasher: RandomState,
-        rng: SmallRng,
+        rng: Xoshiro256PlusPlus,
     ) -> Self {
         // Pre-allocate with capacity to avoid resizing
         let mut buckets = Vec::with_capacity(depth);
@@ -571,7 +587,7 @@ impl<T: Ord + Clone + Hash> Builder<T> {
             }
         });
 
-        let rng = SmallRng::seed_from_u64(self.seed.unwrap_or(0));
+        let rng = Xoshiro256PlusPlus::seed_from_u64(self.seed.unwrap_or(0));
 
         Ok(TopK::with_components(k, width, depth, decay, hasher, rng))
     }
@@ -1374,7 +1390,10 @@ mod tests {
             9,
             "Item1 bucket count should be 9 after decay"
         );
-        assert!(!topk.contains(&item2), "Item2 should not be in the bucket yet");
+        assert!(
+            !topk.contains(&item2),
+            "Item2 should not be in the bucket yet"
+        );
         assert_eq!(
             topk.bucket_count(&item2),
             0,

--- a/src/heavykeeper.rs
+++ b/src/heavykeeper.rs
@@ -68,6 +68,34 @@ pub enum BuilderError {
     MissingField { field: String },
 }
 
+#[derive(Error, Debug)]
+pub enum TopKDeserializeError {
+    #[error(
+        "Byte stream too short while reading {field}: need {needed} more byte(s), have {actual}"
+    )]
+    UnexpectedEof {
+        field: &'static str,
+        needed: usize,
+        actual: usize,
+    },
+
+    #[error("Unsupported serialization version {version} (this build expects {expected})")]
+    UnsupportedVersion { version: u8, expected: u8 },
+
+    #[error("Invalid {field} value: {detail}")]
+    InvalidField { field: &'static str, detail: String },
+
+    #[error("Length mismatch for {field}: payload holds {actual} but expected {expected}")]
+    LengthMismatch {
+        field: &'static str,
+        actual: usize,
+        expected: usize,
+    },
+
+    #[error("{count} unexpected trailing byte(s) after the sketch payload")]
+    TrailingBytes { count: usize },
+}
+
 #[derive(Clone)]
 pub struct TopK<T: Ord + Clone + Hash> {
     top_items: usize,
@@ -470,6 +498,207 @@ impl<T: Ord + Clone + Hash> TopK<T> {
         }
 
         Ok(())
+    }
+}
+
+const VERSION: u8 = 1;
+const CELL_SIZE: usize = 16;
+const RNG_STATE_SIZE: usize = 32;
+
+/// Narrow a `u64` to `usize`, erroring on overflow.
+fn decoded_usize(value: u64, field: &'static str) -> Result<usize, TopKDeserializeError> {
+    usize::try_from(value).map_err(|_| TopKDeserializeError::InvalidField {
+        field,
+        detail: format!("value {value} exceeds usize range on this platform"),
+    })
+}
+
+/// Parse a `CELL_SIZE`-aligned slice into `depth` rows of `width` buckets.
+fn parse_buckets(slice: &[u8], width: usize) -> Vec<Vec<Bucket>> {
+    slice
+        .chunks_exact(width * CELL_SIZE)
+        .map(|row| {
+            row.chunks_exact(CELL_SIZE)
+                .map(|chunk| Bucket {
+                    fingerprint: u64::from_le_bytes(chunk[0..8].try_into().expect("8 bytes")),
+                    count: u64::from_le_bytes(chunk[8..16].try_into().expect("8 bytes")),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Bounds-checked read of `n` bytes at `*pos`, advancing it.
+fn take<'a>(
+    bytes: &'a [u8],
+    pos: &mut usize,
+    n: usize,
+    field: &'static str,
+) -> Result<&'a [u8], TopKDeserializeError> {
+    let available = bytes.len().saturating_sub(*pos);
+    if available < n {
+        return Err(TopKDeserializeError::UnexpectedEof {
+            field,
+            needed: n,
+            actual: available,
+        });
+    }
+    let slice = &bytes[*pos..*pos + n];
+    *pos += n;
+    Ok(slice)
+}
+
+/// Read a little-endian `u64` at `*pos`, advancing it.
+fn take_u64(
+    bytes: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<u64, TopKDeserializeError> {
+    Ok(u64::from_le_bytes(
+        take(bytes, pos, 8, field)?
+            .try_into()
+            .expect("slice is 8 bytes"),
+    ))
+}
+
+impl TopK<Vec<u8>> {
+    /// Serialize the sketch to a byte stream. Layout (little-endian):
+    ///
+    /// ```text
+    /// version: u8
+    /// width, depth, decay(bits), top_items: u64 each
+    /// buckets:  depth  x  width  x (fingerprint: u64, count: u64)
+    /// pq_len: u64
+    /// pq:       pq_len       x (key_len: u64, key bytes, count: u64)
+    /// rng_state: 32 bytes
+    /// ```
+    ///
+    /// The seed is not stored; the hasher is rebuilt from the seed passed to
+    /// [`from_bytes`](TopK::from_bytes). The RNG position is stored
+    /// (`rng_state`) and restored exactly.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let cell_count = self.depth * self.width;
+        let pq_len = self.priority_queue.len();
+        let mut out =
+            Vec::with_capacity(1 + 8 * 4 + cell_count * CELL_SIZE + pq_len * 24 + RNG_STATE_SIZE);
+
+        out.push(VERSION);
+        out.extend_from_slice(&(self.width as u64).to_le_bytes());
+        out.extend_from_slice(&(self.depth as u64).to_le_bytes());
+        out.extend_from_slice(&self.decay.to_bits().to_le_bytes());
+        out.extend_from_slice(&(self.top_items as u64).to_le_bytes());
+
+        for bucket in self.buckets.iter().flatten() {
+            out.extend_from_slice(&bucket.fingerprint.to_le_bytes());
+            out.extend_from_slice(&bucket.count.to_le_bytes());
+        }
+
+        // Serialize in insertion-`sequence` order (not count order) so restore
+        // preserves the count-tie ordering; see `TopKQueue::iter_by_sequence`.
+        out.extend_from_slice(&(pq_len as u64).to_le_bytes());
+        for (item, count) in self.priority_queue.iter_by_sequence() {
+            out.extend_from_slice(&(item.len() as u64).to_le_bytes());
+            out.extend_from_slice(item);
+            out.extend_from_slice(&count.to_le_bytes());
+        }
+        out.extend_from_slice(&self.random.state());
+
+        out
+    }
+
+    /// Reconstruct a sketch from [`to_bytes`](TopK::to_bytes) output.
+    /// `seed` must match the sketch's original seed; the hasher rebuilt from it.
+    pub fn from_bytes(bytes: &[u8], seed: u64) -> Result<Self, TopKDeserializeError> {
+        let mut pos = 0;
+
+        let version = take(bytes, &mut pos, 1, "version")?[0];
+        if version != VERSION {
+            return Err(TopKDeserializeError::UnsupportedVersion {
+                version,
+                expected: VERSION,
+            });
+        }
+        let width = decoded_usize(take_u64(bytes, &mut pos, "width")?, "width")?;
+        let depth = decoded_usize(take_u64(bytes, &mut pos, "depth")?, "depth")?;
+        let decay = f64::from_bits(take_u64(bytes, &mut pos, "decay")?);
+        let top_items = decoded_usize(take_u64(bytes, &mut pos, "top_items")?, "top_items")?;
+
+        // Validate scalars before sizing anything off them.
+        if width < 1 {
+            return Err(TopKDeserializeError::InvalidField {
+                field: "width",
+                detail: format!("must be >= 1, got {width}"),
+            });
+        }
+        if depth < 1 {
+            return Err(TopKDeserializeError::InvalidField {
+                field: "depth",
+                detail: format!("must be >= 1, got {depth}"),
+            });
+        }
+        if !decay.is_finite() || !(0.0..=1.0).contains(&decay) {
+            return Err(TopKDeserializeError::InvalidField {
+                field: "decay",
+                detail: format!("must be a finite value in 0.0..=1.0, got {decay}"),
+            });
+        }
+
+        // `take` checks the bytes exist before `parse_buckets` allocates, so a
+        // corrupt geometry can't force a huge allocation.
+        let cell_count =
+            width
+                .checked_mul(depth)
+                .ok_or_else(|| TopKDeserializeError::InvalidField {
+                    field: "width*depth",
+                    detail: format!("overflows usize ({width} * {depth})"),
+                })?;
+        let bucket_bytes = cell_count.checked_mul(CELL_SIZE).ok_or_else(|| {
+            TopKDeserializeError::InvalidField {
+                field: "buckets",
+                detail: format!("size overflows usize (width*depth={cell_count})"),
+            }
+        })?;
+        let buckets = parse_buckets(take(bytes, &mut pos, bucket_bytes, "buckets")?, width);
+
+        let pq_len = decoded_usize(
+            take_u64(bytes, &mut pos, "priority_queue length")?,
+            "priority_queue length",
+        )?;
+        if pq_len > top_items {
+            return Err(TopKDeserializeError::LengthMismatch {
+                field: "priority queue",
+                actual: pq_len,
+                expected: top_items,
+            });
+        }
+
+        // The `top_items` reserve is an unbounded-header OOM tradeoff; see
+        // `CuckooTopK::from_bytes`.
+        let mut sketch = Self::with_seed(top_items, width, depth, decay, seed);
+        sketch.buckets = buckets;
+
+        for _ in 0..pq_len {
+            let key_len = decoded_usize(
+                take_u64(bytes, &mut pos, "priority_queue key length")?,
+                "priority_queue key length",
+            )?;
+            let item = take(bytes, &mut pos, key_len, "priority_queue key")?.to_vec();
+            let count = take_u64(bytes, &mut pos, "priority_queue count")?;
+            sketch.priority_queue.upsert(item, count);
+        }
+
+        let rng_state: [u8; RNG_STATE_SIZE] = take(bytes, &mut pos, RNG_STATE_SIZE, "rng_state")?
+            .try_into()
+            .expect("slice is RNG_STATE_SIZE bytes");
+        sketch.random = Xoshiro256PlusPlus::from_seed(rng_state);
+
+        if pos != bytes.len() {
+            return Err(TopKDeserializeError::TrailingBytes {
+                count: bytes.len() - pos,
+            });
+        }
+
+        Ok(sketch)
     }
 }
 
@@ -1578,5 +1807,162 @@ mod tests {
         topk.add_with_evicted(&b"hot".to_vec(), 50);
         topk.add_with_evicted(&b"warm".to_vec(), 30);
         assert_eq!(topk.add_with_evicted(&b"cold".to_vec(), 10), (None, false));
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_preserves_state() {
+        let mut original = TopK::<Vec<u8>>::with_seed(50, 64, 4, 0.9, 42);
+        for i in 0u32..200 {
+            original.add(&format!("key-{i}").into_bytes(), (i as u64) + 1);
+        }
+        let restored = TopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        assert_eq!(restored.width, original.width);
+        assert_eq!(restored.depth, original.depth);
+        assert_eq!(restored.decay, original.decay);
+        assert_eq!(restored.top_items, original.top_items);
+        assert_eq!(restored.list(), original.list());
+        for i in 0u32..200 {
+            let key = format!("key-{i}").into_bytes();
+            assert_eq!(
+                restored.count(&key),
+                original.count(&key),
+                "count mismatch for {key:?}"
+            );
+            assert_eq!(
+                restored.bucket_count(&key),
+                original.bucket_count(&key),
+                "bucket_count mismatch for {key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_empty_sketch() {
+        let original = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 7);
+        let restored = TopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 7).expect("round-trips");
+        assert_eq!(restored.list(), original.list());
+        assert!(restored.list().is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_rejects_truncated_stream() {
+        let mut sketch = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        sketch.add(b"foo".as_slice(), 5);
+        let bytes = sketch.to_bytes();
+        let Err(err) = TopK::<Vec<u8>>::from_bytes(&bytes[..bytes.len() - 1], 42) else {
+            panic!("truncated stream must fail");
+        };
+        assert!(matches!(err, TopKDeserializeError::UnexpectedEof { .. }));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_trailing_bytes() {
+        let mut bytes = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes.push(0xff);
+        let Err(err) = TopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("trailing bytes must fail");
+        };
+        assert!(matches!(
+            err,
+            TopKDeserializeError::TrailingBytes { count: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_unsupported_version() {
+        let mut bytes = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        bytes[0] = VERSION + 1;
+        let Err(err) = TopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("bad version must fail");
+        };
+        assert!(matches!(
+            err,
+            TopKDeserializeError::UnsupportedVersion { .. }
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_rejects_zero_width() {
+        let mut bytes = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42).to_bytes();
+        // width is the first u64 right after the 1-byte version.
+        bytes[1..9].copy_from_slice(&0u64.to_le_bytes());
+        let Err(err) = TopK::<Vec<u8>>::from_bytes(&bytes, 42) else {
+            panic!("zero width must fail");
+        };
+        assert!(matches!(
+            err,
+            TopKDeserializeError::InvalidField { field: "width", .. }
+        ));
+    }
+
+    /// Regression: a restored sketch must resume the RNG where the original
+    /// left off, or identical follow-up traffic makes them diverge (the
+    /// primary/replica full-sync case).
+    #[test]
+    fn test_serialize_preserves_rng_position_no_divergence() {
+        // Small width + high decay churn forces the decay path to consume RNG.
+        let mut original = TopK::<Vec<u8>>::with_seed(20, 16, 2, 0.9, 42);
+        for i in 0u32..500 {
+            original.add(&format!("warmup-{}", i % 40).into_bytes(), 3);
+        }
+
+        let mut restored =
+            TopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Feed identical follow-up traffic to both copies.
+        for i in 0u32..500 {
+            let key = format!("live-{}", i % 40).into_bytes();
+            original.add(&key, 3);
+            restored.add(&key, 3);
+        }
+
+        // Full state (incl. rng_state) is more sensitive than `list()` alone.
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
+    }
+
+    #[test]
+    fn test_serialize_appends_rng_state() {
+        let empty = TopK::<Vec<u8>>::with_seed(10, 64, 4, 0.9, 42);
+        let bytes = empty.to_bytes();
+        // Header (version + 4 u64s) + buckets + pq_len + rng state.
+        let header = 1 + 8 * 4;
+        let cells = 64 * 4 * CELL_SIZE;
+        let pq_len = 8;
+        assert_eq!(bytes.len(), header + cells + pq_len + RNG_STATE_SIZE);
+    }
+
+    /// Regression: equal-count items must keep their order across a round-trip.
+    /// `a` is inserted first but has the lower count at snapshot time; count-order
+    /// serialization would flip the tie once follow-up traffic levels the counts.
+    #[test]
+    fn test_serialize_preserves_pq_tie_order() {
+        // Wide sketch so fingerprints don't collide and counts stay exact.
+        let mut original = TopK::<Vec<u8>>::with_seed(4, 1024, 4, 0.9, 42);
+        original.add(b"a".as_slice(), 10); // inserted first (lower sequence)
+        original.add(b"b".as_slice(), 20); // inserted second, higher count
+
+        let mut restored =
+            TopK::<Vec<u8>>::from_bytes(&original.to_bytes(), 42).expect("round-trips");
+
+        // Identical follow-up traffic levels the counts, forming a tie.
+        original.add(b"a".as_slice(), 10);
+        restored.add(b"a".as_slice(), 10);
+
+        let order = |s: &TopK<Vec<u8>>| s.list().into_iter().map(|n| n.item).collect::<Vec<_>>();
+        assert_eq!(
+            order(&restored),
+            order(&original),
+            "equal-count items must keep their order across a round-trip"
+        );
+        assert_eq!(
+            restored.to_bytes(),
+            original.to_bytes(),
+            "restored sketch diverged from original after identical traffic"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,9 @@ mod bucketed;
 pub use bucketed::{BucketedBuilderError, BucketedMergeError, BucketedNode, BucketedTopK};
 
 mod cuckoo;
-pub use cuckoo::{CuckooBuilderError, CuckooMergeError, CuckooNode, CuckooTopK};
+pub use cuckoo::{
+    CuckooBuilderError, CuckooDeserializeError, CuckooMergeError, CuckooNode, CuckooTopK,
+};
 
 mod hash_composition;
 mod priority_queue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@ mod heavykeeper;
 pub use heavykeeper::{TopK, TopKDeserializeError, TopKNode};
 
 mod bucketed;
-pub use bucketed::{BucketedBuilderError, BucketedMergeError, BucketedNode, BucketedTopK};
+pub use bucketed::{
+    BucketedBuilderError, BucketedDeserializeError, BucketedMergeError, BucketedNode, BucketedTopK,
+};
 
 mod cuckoo;
 pub use cuckoo::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Shigang Chen, University of Florida; Lorna Uden, Staffordshire University; Xiaoming Li, Peking University
 
 mod heavykeeper;
-pub use heavykeeper::{TopK, TopKNode};
+pub use heavykeeper::{TopK, TopKDeserializeError, TopKNode};
 
 mod bucketed;
 pub use bucketed::{BucketedBuilderError, BucketedMergeError, BucketedNode, BucketedTopK};

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -35,10 +35,6 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len()
     }
 
-    pub(crate) fn set_capacity(&mut self, capacity: usize) {
-        self.capacity = capacity;
-    }
-
     /// Returns the heap memory (in bytes) used by this queue's containers.
     ///
     /// Computed from the allocated *capacity* of the `HashMap`, heap vector,

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -35,6 +35,10 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         self.items.len()
     }
 
+    pub(crate) fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity;
+    }
+
     /// Returns an estimate of heap memory (in bytes) used by this queue.
     ///
     /// Computed from allocated *capacity* of the `HashMap`, heap vector,

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -210,6 +210,23 @@ impl<T: Ord + Clone + Hash + PartialEq> TopKQueue<T> {
         items.into_iter().map(|(k, count, _)| (k, count))
     }
 
+    /// Iterate items in ascending insertion-`sequence` order.
+    ///
+    /// Serialization uses this so restore (re-`upsert` in this order) reassigns
+    /// sequences that preserve the count-tie ordering.
+    pub(crate) fn iter_by_sequence(&self) -> impl Iterator<Item = (&T, u64)> {
+        let mut items: Vec<_> = self
+            .items
+            .iter()
+            .map(|(k, (count, heap_idx))| {
+                let seq = self.heap[*heap_idx].1;
+                (k, *count, seq)
+            })
+            .collect();
+        items.sort_unstable_by_key(|(_, _, seq)| *seq);
+        items.into_iter().map(|(k, count, _)| (k, count))
+    }
+
     // Binary heap helper methods using Eytzinger layout (0-based indexing)
     fn parent(i: usize) -> usize {
         (i - 1) >> 1


### PR DESCRIPTION
## Motivation

Downstream consumers like valkey-bloom (https://github.com/valkey-io/valkey-bloom) need to persist and restore sketch state across process restarts and replica full syncs. Since the sketch internals (buckets/cells, RNG, priority queue) are crate-private, serialization must live here rather than in the downstream library.

This PR adds `to_bytes` (save) and `from_bytes` (load / restore) to all three sketch variants (`TopK`, `BucketedTopK`, `CuckooTopK`), plus the supporting RNG change.

Related to issue #56 , which raises the same serialization need. This PR addresses it with a hand-written byte format; the other half of that discussion (a deterministic / cross-architecture hasher) is out of scope here.

## Design

### 1. RNG: `SmallRng` → `Xoshiro256PlusPlus`

The sketches use an RNG for probabilistic decay. To keep a restored sketch in lockstep with the original, the RNG's exact position must survive the round-trip, otherwise identical follow-up traffic will cause the two to drift apart over time.

`SmallRng` implements `Clone` but exposes **no way to extract or reconstruct its internal state**, so it can't be serialized. We switched to [`rand_xoshiro::Xoshiro256PlusPlus`](https://docs.rs/rand_xoshiro), which provides exactly the API we need:
- `state() -> [u8; 32]` — export the 256-bit internal state, and
- `from_seed([u8; 32])` — rebuild an RNG at that exact state.

`to_bytes` writes `rng.state()` and `from_bytes` restores it via `from_seed`, resuming the decay stream exactly.

> Note: `rand_xoshiro` re-exports `rand_core` 0.10 (not the 0.9 that `rand` uses); in 0.10 `next_u64` lives on the `Rng` trait rather than `RngCore`, hence the trait import.

### 2. Tie-break ordering: `iter_by_sequence`

The priority queue breaks ties between **equal-count** items using an internal `sequence` counter : `iter()` yields items sorted by count descending, then sequence ascending. That `sequence` is an internal detail and is **not** serialized.

Restore re-inserts items via `upsert`, which assigns each a **fresh** sequence in the order they're replayed. If we serialized in `iter()`'s count-descending order, equal-count items would be renumbered by count rank rather than original insertion order — and once follow-up traffic levels their counts into a tie, a restored replica would order them **differently from the original** (different `list()` output).

Example — `a` inserted before `b`:

| key | count | seq |
|-----|-------|-----|
| b   | 20    | 2   |
| a   | 10    | 1   |

Serializing count-descending replays `b, a`, so on restore `b`→seq 1, `a`→seq 2 (relative order flips). Add `+10` to `a` on both sides so both are 20: the original (a.seq=1 < b.seq=2) lists `a, b`; the restored copy lists `b, a`. Diverged.

Fix: serialize the queue in **insertion-sequence order** via the new `TopKQueue::iter_by_sequence()`. On restore, `upsert` then reassigns sequences in that same order, preserving the relative order. Because the tie-break only depends on the *relative* order of sequences, we don't need to store the sequence numbers (replaying them in the right order is enough). Each variant has a regression test (`test_serialize_preserves_pq_tie_order`) that fails on the old count-order path and passes with the fix.

### 3. `seed` as a `from_bytes` parameter

`from_bytes(bytes, seed)` takes the seed as a caller-supplied argument (the downstream persists it separately and passes it back). This is a deliberate trade-off:

- The seed determines the **hasher** (`RandomState::with_seeds(seed, …)`), which fixes every fingerprint and bucket index. It must be identical on restore or the sketch is meaningless. But `ahash::RandomState` exposes **no way to recover the seed** from a constructed hasher, so it can't be derived back from the sketch.
- Folding it into the byte stream would require **adding a `seed` field to each sketch struct** purely to carry it to `to_bytes`, and that field would be meaningless for sketches built via `with_hasher(...)` (a caller-supplied `RandomState` with no associated seed), forcing a placeholder value.
- To avoid growing the structs and adding a placeholder-only field, we keep `seed` out of the struct and out of the payload, and re-supply it at `from_bytes`.

Trade-off, stated plainly: the caller must pair the right seed with the right payload — a wrong seed silently produces a corrupt-but-valid-looking sketch. Acceptable versus the struct churn; can be revisited (folded into the stream) if the format is ever revved.

## Serialization Format

Each variant serializes to a versioned, little-endian byte stream. A leading `version: u8` lets us evolve the format later; deserialization rejects unknown versions. All three share the same shape — header, cells, priority queue, RNG state — differing only in the cell geometry each sketch uses.

**`TopK`** (`buckets: Vec<Vec<Bucket>>`, `depth` rows × `width`):
```text
version: u8
width, depth, decay(bits), top_items: u64 each
buckets:   depth x width x (fingerprint: u64, count: u64)
pq_len: u64
pq:        pq_len x (key_len: u64, key bytes, count: u64)
rng_state: 32 bytes
```

**`BucketedTopK`** (`cells: Box<[Cell]>`, flat `width*depth`):
```text
version: u8
width, depth, decay(bits), top_items: u64 each
cells:     width*depth x (fingerprint: u64, count: u64)
pq_len: u64
pq:        pq_len x (key_len: u64, key bytes, count: u64)
rng_state: 32 bytes
```

**`CuckooTopK`** (split `lobbies` + `heavy`, plus a `max_kicks` parameter):
```text
version: u8
width, depth, decay(bits), top_items, max_kicks: u64 each
lobbies:   width x (fingerprint: u64, count: u64)
heavy:     width*depth x (fingerprint: u64, count: u64)
pq_len: u64
pq:        pq_len x (key_len: u64, key bytes, count: u64)
rng_state: 32 bytes
```

Notes:
- **Only `Vec<u8>`-keyed sketches are serializable** (`impl TopK<Vec<u8>>` etc.). Keys are the one variable-length, type-dependent part; `Vec<u8>` matches the downstream use case and keeps the format simple.
- **Derived fields are recomputed, not stored** — `width_mask` and the `decay_thresholds` lookup table are rebuilt from the restored `width` / `decay`.
- **Deserialization is defensive.** A dedicated `…DeserializeError` per variant reports truncation (`UnexpectedEof`), unknown `version`, invalid geometry / params (`InvalidField`, e.g. `width == 0`, non-finite `decay`), an oversized priority queue (`LengthMismatch`, `pq_len > top_items`), and leftover `TrailingBytes`. Every allocation is gated behind a bounds-checked read, and size products use `checked_mul`, so a corrupt geometry can't trigger a huge allocation. 
- One documented exception: the `top_items`-sized priority-queue reserve is sized from the header — fine for restoring our own dumps, noted in-code for any future untrusted-input use.

## Changes
- `Cargo.toml`: add `rand_xoshiro`.
- All sketches: `SmallRng` → `Xoshiro256PlusPlus`.
- `TopK`, `BucketedTopK`, `CuckooTopK`: add `to_bytes` / `from_bytes` + `…DeserializeError`, exported from the crate root.
- `priority_queue`: add `iter_by_sequence()`.

## Tests
- Per-variant round-trip, corruption / rejection, RNG-position, and tie-order regression tests.
- `cargo test` — 146 tests pass. `cargo clippy` — clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added byte-based serialization and deserialization for multiple sketches, including full state restoration (parameters, queued items, and RNG position/state).
  * Expanded crate-level exports for new deserialization error types.

* **Bug Fixes**
  * Added strict validation to reject malformed, truncated, trailing, unsupported-version, and invalid-input saved data.
  * Preserved ordering/tie behavior and replay consistency after round-tripping serialized sketches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->